### PR TITLE
Feat/frontend integtation preparing

### DIFF
--- a/frontend/frontend-backend-communication.md
+++ b/frontend/frontend-backend-communication.md
@@ -1,0 +1,192 @@
+
+
+Daten für Frontend laden
+
+# 1.GET Items Strategie
+
+## Müssen alle root_items geladen werden
+
+GET /api/items/root?=true (nicht vorhanden)
+
+
+ob Item ein Collection ist
+
+## Wenn Item Collection ist
+
+rekursiv children laden
+
+GET /api/collections/{id}/items
+
+order mitgeladet wird (beeinflusst ui)
+
+position wird auch mitgeladet 
+
+muss wie GET /api/items/root?=true funktionieren, isCollection muss mitgeschickt werden
+
+## Item_Content werden pro Aufgabe sofort geschickt 
+
+# Aufgabe addieren Button (root)
+
+
+
+POST /api/items 
+# Collection addieren Button (root)
+
+POST /api/collections (Logik nicht vorhanden, die Rute ist eher für Umwandlung)
+
+Erstellt Item das auch Collection ist
+
+erst Item erstellen, darunter Collection
+
+
+## Kollektion Umwandlung:
+
+POST /api/items/{id}/collection (vorhanden aber andere Rute)
+
+
+# Items zu Kollektion addieren
+
+POST /api/collection/{id}/items (nicht vorhanden)
+
+es geht um Sub_Items von db_schema
+
+wenn Kollektion geordnet war muss bei dem Backend ordering korrigiert werden
++reordering requests wenn Kollektion geordnet war
+
+# Items bei der Kollektion löschen
+
+es geht um Sub_Items von db_schema
+
+DELETE /api/items/{id}
+
+Müssen auch alles was davon abhängig gelöscht werden
+
+Nämlich Item_Contents und Collections
+
+(Beziehung mit Collection bei Items Erstellen) OneToOne
+
+wenn Kollektion geordnet war muss bei dem Backend ordering korrigiert werden
++reordering requests wenn Kollektion geordnet war
+
+# ORDER/NO ORDER
+
+
+## 1. ORDER bei einer Kollektion ändern
+
+PUT /api/collections/{id}/order
+order = true 
+
+
+Bei dem Backend muss zufällige/nach Erstellungszeit die Positionen gegeben (so behebt man das Problem, wenn Zwischenstand fehlerhaft sein kann (es alles wenn position nicht vorhanden ist)) 
+(order wird mitgeschickt)
+
+REORDERING
+
+PUT /api/collection/{id}/items/{id}         : x mal
+mit position
+muss geprüft werden ob Collection order=true hat
+mit position Änderung 
+
+
+## ORDER Löschen
+
+PUT /api/collections/{id}
+
+order = false
+
+(BACKEND kümmert selbst um das Löschen der Positionen
+
+BACKEND setzt null) -- VERALTET, UNTEN ERKLÄRUNG
+
+muss man nicht. können die Items Positions behalten, es wird beim order=false einfach im Frontend nicht angezeigt
+
+
+------------------------------------------
+
+
+
+# Strukturierung der Items
+
+
+# Unabhängiges Item -> Kollektion
+
+heißt Item hat kein parent oder root_item_id
+
+POST /api/collection/{id}/items
+
+root_item bei dem Item wird gesetzt
+
+es wird sub_item erstellt mit id von dem Collection und dem Item
+
+# Item von anderen Kollektion-> Kollektion
+
+### 1. Beziehung löschen
+Es geht nur um Beziehung, für das Löschen der Items ist andere Rute reserviert
+
+DELETE /api/collections/{id}/items/{id}
+
+das Item in dem Fall muss root_item werden
+
+bei dem Item wird root_item_id gelöscht
+
+sub_item wird gelöscht (es geht nur um Beziehung)
+
+
+### 2. Neue Beziehung erstellen
+
+(es war schon bei: 
+# Unabhängiges Item -> Kollektion
+
+heißt Item hat kein parent oder root_item_id
+
+POST /api/collection/{id}/items
+
+root_item bei dem Item wird gesetzt
+
+es wird sub_item erstellt mit id von dem Collection und dem Item
+
+
+
+)
+
+
+# Unabhängige Kollektion (root) unter andere Kollektion schieben
+
+
+Erst Item(ist Kollektion) zu der Kollektion addieren
+
+POST /api/collection/{id}/items
+
+wie bei andere Items. 
+
+da muss aber das Backend (iterativ/rekursiv) sich darum kümmern, dass die Items, die die Kollektion hat, richtiges root_item_id von der neuen Kollektion bekommen. Falls die Kollektion geordenet war, muss dem Item(Kollektion) weitere Position geordnet werden
+
+Danach Falls die Kollektion geordenete war, muss noch von Frontend nochmals die Reordering Strategie erfolgen
+
+Begründung:
+
+darum muss Backend sich kümmern, sonst können nicht erlaubte Verbindungen entstehen, weil während der Veränderung können Zwischenständen der Bäumen existieren, wobei die Items nicht richtige root_item_id haben. 
+
+
+und 
+
+Sub item wird erstellt das Subitem für das Item(is Collection)
+
+# bei Abhängigen (nicht root) Kollektion
+
+so wie bei unabhängige müssen aber erst überall root_item_id auf null gesetzt werden und sub_item bezehung muss gelöscht werden. Als wird das Item(Kollektion) erst unbhängig (root)
+
+DELETE /api/collections/{alterParenTId}/items/{itemId} 
+
+reorderings strategien müssen da auch berücksichtigt werden
+
+
+# *PRÄSI*
+
+
+1. Anforderungen
+2. Tech Stack
+3. Datenbankschema
+4. Stand, Auflistung der Features, Welche Features noch nicht
+5. Strategien Visualisation Item Verbindung
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
+    "dev:dummy": "vite --mode dummy",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",

--- a/frontend/src/feature/aufgabendatenbank/Adb.vue
+++ b/frontend/src/feature/aufgabendatenbank/Adb.vue
@@ -34,7 +34,7 @@ const store = useExerciseStore()
 const { sidebarWidth, containerRef, startResizing } = useSidebarResizer()
 
 onMounted(() => {
-  store.validate()
+  store.loadTree()
 })
 </script>
 

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -1,0 +1,171 @@
+import axios, { type AxiosInstance } from 'axios'
+import type {
+  ApiAdapter,
+  ItemDTO,
+  CollectionItemDTO,
+  CreateItemPayload,
+  CreateCollectionPayload,
+  UpdateCollectionPayload
+} from './api-adapter.types'
+
+/**
+ * Real HTTP implementation of {@link ApiAdapter}.
+ *
+ * Sends actual HTTP requests to the Spring Boot backend using axios.
+ * Paths follow `frontend/frontend-backend-communication.md`.
+ *
+ * ## Usage
+ * ```ts
+ * import adbApi from '@/feature/aufgabendatenbank/adbApi.service'
+ * const items = await adbApi.getRootItems()
+ * ```
+ *
+ * ## Switching to dev mode
+ * To use the dev/logging adapter instead, change the import in `main.ts`.
+ *
+ * @see DevAdbApiService
+ */
+export class AdbApiService implements ApiAdapter {
+  private readonly http: AxiosInstance
+
+  /**
+   * @param baseURL - Backend base URL. Defaults to `/api` so it works with
+   * the Vite proxy configuration out of the box.
+   */
+  constructor(baseURL = '/api') {
+    this.http = axios.create({
+      baseURL,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+
+  /**
+   * **GET /api/items?root=true**
+   *
+   * Loads all root-level items (items without a parent collection).
+   * Each item includes its `contents` inline. Response does NOT include
+   * nested children — those are loaded on demand via {@link getCollectionItems}.
+   */
+  async getRootItems(): Promise<ItemDTO[]> {
+    const { data } = await this.http.get<ItemDTO[]>('/items', { params: { root: true } })
+    return data
+  }
+
+  /**
+   * **GET /api/collections/{id}/items**
+   *
+   * Loads the direct children of a collection. Each child includes its
+   * `position` and the full nested `item` DTO.
+   */
+  async getCollectionItems(collectionId: string): Promise<CollectionItemDTO[]> {
+    const { data } = await this.http.get<CollectionItemDTO[]>(`/collections/${collectionId}/items`)
+    return data
+  }
+
+  /**
+   * **POST /api/items**
+   *
+   * Creates a new item. The backend assigns the `id` and returns
+   * the persisted DTO.
+   */
+  async createItem(payload: CreateItemPayload): Promise<ItemDTO> {
+    const { data } = await this.http.post<ItemDTO>('/items', payload)
+    return data
+  }
+
+  /**
+   * **POST /api/collections**
+   *
+   * Creates a root collection: the backend creates an Item with
+   * `item_type='collection'` plus the corresponding Collection record.
+   * This is NOT for converting existing items — use {@link convertItemToCollection}.
+   */
+  async createCollection(payload: CreateCollectionPayload): Promise<ItemDTO> {
+    const { data } = await this.http.post<ItemDTO>('/collections', payload)
+    return data
+  }
+
+  /**
+   * **POST /api/items/{id}/collection**
+   *
+   * Converts an existing exercise item into a collection.
+   * The backend flips `item_type` to 'collection' and creates
+   * the corresponding Collection record.
+   */
+  async convertItemToCollection(itemId: string): Promise<ItemDTO> {
+    const { data } = await this.http.post<ItemDTO>(`/items/${itemId}/collection`)
+    return data
+  }
+
+  /**
+   * **POST /api/collection/{id}/items**
+   *
+   * Adds an existing item to a collection by creating a CollectionItem record.
+   * If the target collection is ordered, the backend auto-assigns a position.
+   */
+  async addItemToCollection(collectionId: string, itemId: string): Promise<CollectionItemDTO> {
+    const { data } = await this.http.post<CollectionItemDTO>(`/collection/${collectionId}/items`, { itemId })
+    return data
+  }
+
+  /**
+   * **DELETE /api/collections/{id}/items/{itemId}**
+   *
+   * Removes an item from a collection — breaks the relationship only.
+   * The item itself is NOT deleted; its `rootItemId` becomes `null`
+   * (making it a root item).
+   */
+  async removeItemFromCollection(collectionId: string, itemId: string): Promise<void> {
+    await this.http.delete(`/collections/${collectionId}/items/${itemId}`)
+  }
+
+  /**
+   * **DELETE /api/items/{id}**
+   *
+   * Deletes an item with cascade:
+   * - Item_Content records
+   * - Collection record (if item is a collection)
+   * - CollectionItem join records
+   */
+  async deleteItem(itemId: string): Promise<void> {
+    await this.http.delete(`/items/${itemId}`)
+  }
+
+  /**
+   * **PUT /api/collections/{id}**
+   *
+   * Updates collection metadata. Used to toggle `order` on or off.
+   * When toggling on, the backend auto-assigns sequential positions.
+   * When toggling off, positions are kept (UI hides them).
+   */
+  async updateCollection(collectionId: string, payload: UpdateCollectionPayload): Promise<ItemDTO> {
+    const { data } = await this.http.put<ItemDTO>(`/collections/${collectionId}`, payload)
+    return data
+  }
+
+  /**
+   * **PUT /api/collection/{id}/items/{itemId}**
+   *
+   * Updates the position of an item within an ordered collection
+   * (triggered by drag-and-drop reorder).
+   * The backend recalculates sibling positions to maintain a gapless sequence.
+   */
+  async updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void> {
+    await this.http.put(`/collection/${collectionId}/items/${itemId}`, { position })
+  }
+
+  /**
+   * Loads all root items without nesting children.
+   *
+   * Progressive recursive loading is handled by the store —
+   * see {@link useExerciseStore._loadChildrenRecursively}.
+   * This method just returns the top level; children are fetched
+   * on demand via {@link getCollectionItems}.
+   */
+  async loadFullTree(): Promise<ItemDTO[]> {
+    return this.getRootItems()
+  }
+}
+
+/** Singleton instance, pre-configured with the default `/api` base URL. */
+export default new AdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -2,8 +2,10 @@ import axios, { type AxiosInstance } from 'axios'
 import type {
   ApiAdapter,
   ItemDTO,
+  ContentDTO,
   CollectionItemDTO,
   CreateItemPayload,
+  CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload
 } from './api-adapter.types'
@@ -152,6 +154,45 @@ export class AdbApiService implements ApiAdapter {
    */
   async updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void> {
     await this.http.put(`/collection/${collectionId}/items/${itemId}`, { position })
+  }
+
+  /**
+   * **GET /api/items/{itemId}/contents**
+   *
+   * Returns all content blocks for an item.
+   */
+  async getContents(itemId: string): Promise<ContentDTO[]> {
+    const { data } = await this.http.get<ContentDTO[]>(`/items/${itemId}/contents`)
+    return data
+  }
+
+  /**
+   * **POST /api/items/{itemId}/contents**
+   *
+   * Creates a new content block for an item.
+   */
+  async createContent(itemId: string, payload: CreateContentPayload): Promise<ContentDTO> {
+    const { data } = await this.http.post<ContentDTO>(`/items/${itemId}/contents`, payload)
+    return data
+  }
+
+  /**
+   * **PUT /api/contents/{id}**
+   *
+   * Updates an existing content block.
+   */
+  async updateContent(contentId: string, payload: CreateContentPayload): Promise<ContentDTO> {
+    const { data } = await this.http.put<ContentDTO>(`/contents/${contentId}`, payload)
+    return data
+  }
+
+  /**
+   * **DELETE /api/contents/{id}**
+   *
+   * Deletes a content block.
+   */
+  async deleteContent(contentId: string): Promise<void> {
+    await this.http.delete(`/contents/${contentId}`)
   }
 
   /**

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -1,0 +1,232 @@
+/**
+ * API adapter contract and DTOs for the Aufgabendatenbank feature.
+ *
+ * ## Architecture
+ * The store depends on the {@link ApiAdapter} interface (Dependency Inversion).
+ * Two implementations exist:
+ * - {@link AdbApiService} — real HTTP calls via axios (production)
+ * - {@link DevAdbApiService} — logs requests, returns dummy data (development)
+ *
+ * Switching between them is a one-line change in `main.ts` (Pinia plugin).
+ *
+ * ## Endpoint reference
+ * All paths follow `frontend/frontend-backend-communication.md`.
+ * Note the inconsistent pluralisation ("collection" vs "collections") — this
+ * matches the backend routes as defined in that spec.
+ */
+
+// ── API DTOs ──────────────────────────────────────────────────────────────────
+
+/**
+ * Content block DTO returned by the API.
+ * Each item has zero or more content blocks, linked by `purpose`.
+ */
+export interface ContentDTO {
+  id?: string
+  license: string | null
+  contentType: string
+  author: string
+  purpose: string
+  jsonContent: Record<string, unknown>
+  blobContent: string
+}
+
+/**
+ * Collection sub-item DTO returned by the API.
+ * Represents an item nested inside a collection, with an optional `position`.
+ * When the parent collection has `order: true`, `position` is a positive integer
+ * indicating the item's place in the sequence. When `order: false`, `position`
+ * is `null` (but may still contain stale values — the UI hides them per new spec).
+ */
+export interface CollectionItemDTO {
+  id: string
+  collectionId: string
+  item: ItemDTO
+  position: number | null
+}
+
+/**
+ * Item DTO returned by the API.
+ *
+ * If `item_type === 'collection'`, the response includes `items` (children)
+ * and `order` (whether the collection is ordered). Non-collection items omit
+ * both fields.
+ *
+ * **GET /api/items/root?=true** returns items at the root level.
+ * The `isCollection` detection is done via `item_type === 'collection'`.
+ */
+export interface ItemDTO {
+  id: string
+  item_type: string
+  author: string
+  representationTemplate: string | null
+  license: string | null
+  rootItemId?: string | null
+  contents: ContentDTO[]
+  items?: CollectionItemDTO[]
+  order?: boolean
+}
+
+// ── Request payloads ──────────────────────────────────────────────────────────
+
+/**
+ * Payload for **POST /api/items**.
+ *
+ * Creates a new exercise or collection item. The backend assigns `id`.
+ */
+export interface CreateItemPayload {
+  item_type: string
+  author: string
+  rootItemId: string | null
+  contents: CreateContentPayload[]
+}
+
+/**
+ * Payload for **POST /api/collections**.
+ *
+ * Creates a new root collection — the backend first creates an `Item` (with
+ * `item_type='collection'`), then creates the corresponding `Collection` record
+ * with the given `order` flag.
+ *
+ * This endpoint does NOT convert an existing item into a collection; use
+ * **POST /api/items/{id}/collection** for that.
+ */
+export interface CreateCollectionPayload {
+  item_type: 'collection'
+  author: string
+  contents: CreateContentPayload[]
+  order: boolean
+}
+
+/**
+ * Content block payload for create/update operations.
+ */
+export interface CreateContentPayload {
+  license: string | null
+  contentType: string
+  author: string
+  purpose: string
+  jsonContent: Record<string, unknown>
+  blobContent: string
+}
+
+/**
+ * Payload for **PUT /api/collections/{id}**.
+ *
+ * Used to update collection-level metadata (currently only `order`).
+ */
+export interface UpdateCollectionPayload {
+  order: boolean
+}
+
+// ── Adapter Interface ─────────────────────────────────────────────────────────
+
+/**
+ * Abstract API adapter for the Aufgabendatenbank feature.
+ *
+ * The store depends on this interface. Either implementation
+ * (HTTP or dev/logging) can be swapped in via the Pinia plugin in `main.ts`.
+ */
+export interface ApiAdapter {
+/**
+ * **GET /api/items?root=true**
+ *
+ * Loads all root-level items. The backend returns items whose
+ * `rootItemId` is `null`. Each response includes inline `contents`.
+ * Collection items also carry `order` (but `items` is NOT populated here —
+ * children are loaded on demand via {@link getCollectionItems}).
+ */
+  getRootItems(): Promise<ItemDTO[]>
+
+  /**
+   * **GET /api/collections/{id}/items**
+   *
+   * Loads all direct children of a collection.
+   * Each child carries its `position` and nested `item` data.
+   * The parent's `order` flag determines whether positions are meaningful.
+   */
+  getCollectionItems(collectionId: string): Promise<CollectionItemDTO[]>
+
+  /**
+   * **POST /api/items**
+   *
+   * Creates a new item (exercise or collection).
+   * The backend assigns the `id` and returns the persisted DTO.
+   */
+  createItem(payload: CreateItemPayload): Promise<ItemDTO>
+
+  /**
+   * **POST /api/collections**
+   *
+   * Creates a root collection: an Item (item_type='collection') plus
+   * a Collection record. Not for converting existing items.
+   */
+  createCollection(payload: CreateCollectionPayload): Promise<ItemDTO>
+
+  /**
+   * **POST /api/items/{id}/collection**
+   *
+   * Converts an existing exercise item into a collection.
+   * The backend flips `item_type` to 'collection' and creates
+   * the corresponding Collection record.
+   */
+  convertItemToCollection(itemId: string): Promise<ItemDTO>
+
+  /**
+   * **POST /api/collection/{id}/items**
+   *
+   * Adds an existing item to a collection.
+   * Creates a `CollectionItem` record linking the item to the collection.
+   * If the target collection is ordered, the backend auto-assigns a position.
+   * Returns the created CollectionItem.
+   */
+  addItemToCollection(collectionId: string, itemId: string): Promise<CollectionItemDTO>
+
+  /**
+   * **DELETE /api/collections/{id}/items/{itemId}**
+   *
+   * Removes an item from a collection — this breaks the relationship only.
+   * The item itself is NOT deleted; its `rootItemId` is set to `null`
+   * (making it a root item).
+   * If the collection was ordered, the backend recalculates sibling positions.
+   */
+  removeItemFromCollection(collectionId: string, itemId: string): Promise<void>
+
+  /**
+   * **DELETE /api/items/{id}**
+   *
+   * Deletes an item with cascade:
+   * - Associated `Item_Content` records
+   * - `Collection` record (if the item is a collection)
+   * - `CollectionItem` join records (if the item belongs to collections)
+   */
+  deleteItem(itemId: string): Promise<void>
+
+  /**
+   * **PUT /api/collections/{id}**
+   *
+   * Updates collection-level metadata.
+   * Primarily used to set `order: false`.
+   * When order toggles off, positions are kept in the database but the UI
+   * should not display them (per new spec, positions are preserved).
+   */
+  updateCollection(collectionId: string, payload: UpdateCollectionPayload): Promise<ItemDTO>
+
+  /**
+   * **PUT /api/collection/{id}/items/{itemId}**
+   *
+   * Updates the position of an item within an ordered collection
+   * (e.g. after drag-and-drop reorder).
+   * The backend recalculates sibling positions to maintain a gapless sequence.
+   */
+  updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void>
+
+  /**
+   * Load all root items. Children are NOT included — the store loads
+   * them progressively via {@link getCollectionItems} with per-node
+   * loading state, so the UI can show spinners.
+   *
+   * @returns Root-level items only (collections have empty `items`).
+   */
+  loadFullTree(): Promise<ItemDTO[]>
+}

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -222,6 +222,38 @@ export interface ApiAdapter {
   updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void>
 
   /**
+   * **GET /api/items/{itemId}/contents**
+   *
+   * Returns all content blocks attached to an item.
+   * Each content block includes its `id`, `purpose`, `contentType`, etc.
+   */
+  getContents(itemId: string): Promise<ContentDTO[]>
+
+  /**
+   * **POST /api/items/{itemId}/contents**
+   *
+   * Creates a new content block for the given item.
+   * The backend assigns the `id` and links it to the item via `purpose`.
+   * Returns the persisted ContentDTO.
+   */
+  createContent(itemId: string, payload: CreateContentPayload): Promise<ContentDTO>
+
+  /**
+   * **PUT /api/contents/{id}**
+   *
+   * Updates an existing content block's fields.
+   * Accepts the same payload shape as createContent.
+   */
+  updateContent(contentId: string, payload: CreateContentPayload): Promise<ContentDTO>
+
+  /**
+   * **DELETE /api/contents/{id}**
+   *
+   * Deletes a content block and its join-table entries.
+   */
+  deleteContent(contentId: string): Promise<void>
+
+  /**
    * Load all root items. Children are NOT included — the store loads
    * them progressively via {@link getCollectionItems} with per-node
    * loading state, so the UI can show spinners.

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -21,8 +21,10 @@ import { dummyData } from './dummy-data'
 import type {
   ApiAdapter,
   ItemDTO,
+  ContentDTO,
   CollectionItemDTO,
   CreateItemPayload,
+  CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload
 } from './api-adapter.types'
@@ -249,6 +251,50 @@ export class DevAdbApiService implements ApiAdapter {
    */
   async updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void> {
     log('PUT', `/api/collection/${collectionId}/items/${itemId}`, { position })
+  }
+
+  /**
+   * **GET /api/items/{itemId}/contents**
+   *
+   * Finds the item in seed data and returns its contents.
+   */
+  async getContents(itemId: string): Promise<ContentDTO[]> {
+    log('GET', `/api/items/${itemId}/contents`)
+    const roots = dummyData.rootItems as unknown as ItemDTO[]
+    const item = findItemInTree(itemId, roots)
+    if (item && item.contents) return JSON.parse(JSON.stringify(item.contents))
+    return []
+  }
+
+  /**
+   * **POST /api/items/{itemId}/contents**
+   *
+   * Logs the payload and returns a mock ContentDTO.
+   */
+  async createContent(itemId: string, payload: CreateContentPayload): Promise<ContentDTO> {
+    log('POST', `/api/items/${itemId}/contents`, payload)
+    const content: ContentDTO = { id: uid('content'), ...payload }
+    console.log(`  ← ${content.id}`)
+    return content
+  }
+
+  /**
+   * **PUT /api/contents/{id}**
+   *
+   * Logs the payload and returns the updated content.
+   */
+  async updateContent(contentId: string, payload: CreateContentPayload): Promise<ContentDTO> {
+    log('PUT', `/api/contents/${contentId}`, payload)
+    return { id: contentId, ...payload }
+  }
+
+  /**
+   * **DELETE /api/contents/{id}**
+   *
+   * Logs the request only.
+   */
+  async deleteContent(contentId: string): Promise<void> {
+    log('DELETE', `/api/contents/${contentId}`)
   }
 
   /**

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -1,0 +1,266 @@
+/**
+ * Dev/logging implementation of {@link ApiAdapter}.
+ *
+ * Instead of making real HTTP calls, this adapter:
+ * 1. Logs each request (method, path, body) to the browser console
+ * 2. Returns data from the seed `dummy-data.ts` for read operations
+ * 3. Returns plausible auto-generated responses for mutations
+ *
+ * Used in development (`npm run dev:dummy`). Switch to the real
+ * {@link AdbApiService} via `main.ts`.
+ *
+ * ## Console output format
+ * ```
+ * [ADB Dev] GET /api/items?root=true
+ * [ADB Dev] POST /api/items → { item_type: "exercise", ... }
+ * ```
+ *
+ * Mutations also log a second line with the generated ID.
+ */
+import { dummyData } from './dummy-data'
+import type {
+  ApiAdapter,
+  ItemDTO,
+  CollectionItemDTO,
+  CreateItemPayload,
+  CreateCollectionPayload,
+  UpdateCollectionPayload
+} from './api-adapter.types'
+
+function log(method: string, path: string, body?: unknown): void {
+  const parts = [`[ADB Dev] ${method} ${path}`]
+  if (body !== undefined) {
+    parts.push('→', JSON.stringify(body, null, 2))
+  }
+  console.log(...parts)
+}
+
+/**
+ * Deep-clone an ItemDTO to prevent accidental mutation of the seed data.
+ */
+function cloneItem(item: ItemDTO): ItemDTO {
+  return JSON.parse(JSON.stringify(item))
+}
+
+/**
+ * Generate a unique-ish ID based on a prefix and the current timestamp.
+ */
+function uid(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+}
+
+/**
+ * Recursively search a tree of ItemDTOs for an item by ID.
+ * The dummy-data tree may have sub-collections nested arbitrarily deep.
+ */
+function findItemInTree(id: string, items: ItemDTO[]): ItemDTO | undefined {
+  for (const item of items) {
+    if (item.id === id) return item
+    if (item.items) {
+      const found = findItemInTree(id, item.items.map((ci) => ci.item))
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+export class DevAdbApiService implements ApiAdapter {
+  /**
+   * **GET /api/items?root=true**
+   *
+   * Returns deep-cloned root items (children NOT populated — they
+   * are loaded on demand via {@link getCollectionItems}).
+   */
+  async getRootItems(): Promise<ItemDTO[]> {
+    log('GET', '/api/items?root=true')
+    return dummyData.rootItems.map(cloneItem)
+  }
+
+  /**
+   * **GET /api/collections/{id}/items**
+   *
+   * Finds the collection by ID in seed data and returns its children.
+   */
+  async getCollectionItems(collectionId: string): Promise<CollectionItemDTO[]> {
+    log('GET', `/api/collections/${collectionId}/items`)
+    const roots = dummyData.rootItems as unknown as ItemDTO[]
+    const collection = findItemInTree(collectionId, roots)
+    if (collection && collection.items) {
+      return JSON.parse(JSON.stringify(collection.items))
+    }
+    return []
+  }
+
+  /**
+   * **POST /api/items**
+   *
+   * Logs the payload and returns a mock ItemDTO with a generated ID.
+   */
+  async createItem(payload: CreateItemPayload): Promise<ItemDTO> {
+    log('POST', '/api/items', payload)
+    const id = uid('item')
+    const item: ItemDTO = {
+      id,
+      item_type: payload.item_type,
+      author: payload.author,
+      representationTemplate: null,
+      license: null,
+      rootItemId: payload.rootItemId,
+      contents: payload.contents.map((c) => ({
+        id: uid('content'),
+        ...c
+      }))
+    }
+    console.log(`  ← ${id}`)
+    return item
+  }
+
+  /**
+   * **POST /api/collections**
+   *
+   * Logs the payload and returns a mock Collection ItemDTO.
+   */
+  async createCollection(payload: CreateCollectionPayload): Promise<ItemDTO> {
+    log('POST', '/api/collections', payload)
+    const id = uid('coll')
+    const collection: ItemDTO = {
+      id,
+      item_type: 'collection',
+      author: payload.author,
+      representationTemplate: null,
+      license: null,
+      rootItemId: null,
+      contents: payload.contents.map((c) => ({
+        id: uid('content'),
+        ...c
+      })),
+      items: [],
+      order: payload.order
+    }
+    console.log(`  ← ${id}`)
+    return collection
+  }
+
+  /**
+   * **POST /api/items/{id}/collection**
+   *
+   * Logs the request. Finds the item in seed data and returns it with
+   * `item_type` changed to `collection` and empty children.
+   */
+  async convertItemToCollection(itemId: string): Promise<ItemDTO> {
+    log('POST', `/api/items/${itemId}/collection`)
+    const roots = dummyData.rootItems as unknown as ItemDTO[]
+    const item = findItemInTree(itemId, roots)
+    if (item) {
+      const cloned = JSON.parse(JSON.stringify(item)) as ItemDTO
+      cloned.item_type = 'collection'
+      cloned.items = []
+      cloned.order = false
+      return cloned
+    }
+    return {
+      id: itemId,
+      item_type: 'collection',
+      author: 'author',
+      representationTemplate: null,
+      license: null,
+      rootItemId: null,
+      contents: [],
+      items: [],
+      order: false
+    }
+  }
+
+  /**
+   * **POST /api/collection/{id}/items**
+   *
+   * Logs the request and returns a mock CollectionItemDTO.
+   */
+  async addItemToCollection(collectionId: string, itemId: string): Promise<CollectionItemDTO> {
+    log('POST', `/api/collection/${collectionId}/items`, { itemId })
+    const collItem: CollectionItemDTO = {
+      id: uid('coll-item'),
+      collectionId,
+      item: {
+        id: itemId,
+        item_type: 'exercise',
+        author: 'author',
+        representationTemplate: null,
+        license: null,
+        rootItemId: collectionId,
+        contents: []
+      },
+      position: null
+    }
+    console.log(`  ← ${collItem.id}`)
+    return collItem
+  }
+
+  /**
+   * **DELETE /api/collections/{id}/items/{itemId}**
+   *
+   * Logs the request only; no actual mutation in dev mode.
+   */
+  async removeItemFromCollection(collectionId: string, itemId: string): Promise<void> {
+    log('DELETE', `/api/collections/${collectionId}/items/${itemId}`)
+  }
+
+  /**
+   * **DELETE /api/items/{id}**
+   *
+   * Logs the request only; no actual deletion in dev mode.
+   */
+  async deleteItem(itemId: string): Promise<void> {
+    log('DELETE', `/api/items/${itemId}`)
+  }
+
+  /**
+   * **PUT /api/collections/{id}**
+   *
+   * Logs the request. Finds the collection in seed data, applies the update,
+   * and returns the updated clone.
+   */
+  async updateCollection(collectionId: string, payload: UpdateCollectionPayload): Promise<ItemDTO> {
+    log('PUT', `/api/collections/${collectionId}`, payload)
+    const roots = dummyData.rootItems as unknown as ItemDTO[]
+    const collection = findItemInTree(collectionId, roots)
+    if (collection && collection.item_type === 'collection') {
+      const cloned = JSON.parse(JSON.stringify(collection)) as ItemDTO & { items: CollectionItemDTO[]; order: boolean }
+      cloned.order = payload.order
+      return cloned
+    }
+    return {
+      id: collectionId,
+      item_type: 'collection',
+      author: 'author',
+      representationTemplate: null,
+      license: null,
+      rootItemId: null,
+      contents: [],
+      items: [],
+      order: payload.order
+    }
+  }
+
+  /**
+   * **PUT /api/collection/{id}/items/{itemId}**
+   *
+   * Logs the request only; position changes are not persisted in dev mode.
+   */
+  async updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void> {
+    log('PUT', `/api/collection/${collectionId}/items/${itemId}`, { position })
+  }
+
+  /**
+   * Returns root items only (fully populated from seed data for
+   * realistic development). The store drives progressive loading
+   * of children via {@link getCollectionItems}.
+   */
+  async loadFullTree(): Promise<ItemDTO[]> {
+    log('GET', '/api/items?root=true (loadFullTree)')
+    return dummyData.rootItems.map(cloneItem)
+  }
+}
+
+/** Singleton instance for development use. */
+export default new DevAdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/frontend-preparation.md
+++ b/frontend/src/feature/aufgabendatenbank/frontend-preparation.md
@@ -1,0 +1,107 @@
+# Frontend Preparation — API Adapter & Store Refactor
+
+## Session Overview
+
+Complete refactor of the frontend communication layer for the Aufgabendatenbank feature.
+The old `ExerciseApiService` is deprecated. A new strategy-pattern architecture was built:
+
+**ApiAdapter interface** → two implementations:
+- `AdbApiService` — real HTTP (axios, for production)
+- `DevAdbApiService` — logs + seed dummy data (for dev without backend)
+
+---
+
+## Files Created
+
+| File | Purpose |
+|---|---|
+| `api-adapter.types.ts` | `ApiAdapter` interface, all DTOs (`ItemDTO`, `ContentDTO`, `CollectionItemDTO`), request payloads |
+| `adbApi.service.ts` | Real HTTP adapter — singleton axios, paths per `frontend-backend-communication.md` |
+| `dev-adb-api.service.ts` | Dev adapter — console.logs each request, returns `dummy-data.ts` seed data |
+| `.env.dummy` | Env file setting `VITE_ADB_API_MODE=dummy` |
+
+## Files Modified
+
+| File | Changes |
+|---|---|
+| `exerciseStore.ts` | Injected `ApiAdapter` via `setApiAdapter()`; added `loading`/`error` state; progressive loading; auto-sync reorder positions; notification-store for API errors |
+| `main.ts` | Adapter selection based on `VITE_ADB_API_MODE`: `adbApi` (real) vs `devAdbApi` (dummy) |
+| `Adb.vue` | Calls `store.loadTree()` on mount instead of `store.validate()` |
+| `AdbTreeFolder.vue` | Shows `<v-progress-circular>` spinner while collection children load in background |
+| `exerciseApiService.ts` | Added `@deprecated` JSDoc pointing to new `AdbApiService` |
+| `package.json` | Added `"dev:dummy": "vite --mode dummy"` script |
+
+---
+
+## Architecture
+
+```
+main.ts
+  └─ setApiAdapter(devAdbApi | adbApi)       ← env-based selection
+       │
+exerciseStore.ts  (depends on ApiAdapter interface)
+  │  ├─ loadTree()         → adapter.getRootItems() + _loadChildrenRecursively()
+  │  ├─ createItem()       → local + fire-and-forget adapter.createItem()
+  │  ├─ createCollection() → local + fire-and-forget adapter.createCollection()
+  │  ├─ addItemToCollection() → local + adapter.addItemToCollection()
+  │  ├─ deleteItem()       → local + adapter.deleteItem() + _syncOrderedCollectionItems()
+  │  ├─ updateCollectionItems() → local + cross-collection API calls + auto-reorder
+  │  ├─ updateRootItems()  → local + adapter.removeItemFromCollection()
+  │  ├─ toggleCollectionOrder() → adapter.updateCollection(id, { order })  (single endpoint)
+  │  └─ _syncOrderedCollectionItems() → diffs positions, calls adapter.updateCollectionItemPosition()
+  │
+  ├── AdbApiService (adbApi.service.ts)       ← real HTTP, for production
+  └── DevAdbApiService (dev-adb-api.service.ts) ← logs + dummy data, for dev
+```
+
+## Endpoint Mapping (per communication doc)
+
+| Doc Path | adapter method | Notes |
+|---|---|---|
+| `GET /api/items?root=true` | `getRootItems()` | Returns roots w/o children |
+| `GET /api/collections/{id}/items` | `getCollectionItems(id)` | Returns children w/ position |
+| `POST /api/items` | `createItem(payload)` | |
+| `POST /api/collections` | `createCollection(payload)` | Creates Item + Collection record |
+| `POST /api/items/{id}/collection` | `convertItemToCollection(id)` | |
+| `POST /api/collection/{id}/items` | `addItemToCollection(id, itemId)` | Note singular "collection" |
+| `DELETE /api/collections/{id}/items/{itemId}` | `removeItemFromCollection(id, itemId)` | |
+| `DELETE /api/items/{id}` | `deleteItem(id)` | Cascade delete |
+| `PUT /api/collections/{id}` | `updateCollection(id, { order })` | Single endpoint for both on/off |
+| `PUT /api/collection/{id}/items/{itemId}` | `updateCollectionItemPosition(id, itemId, pos)` | Note singular "collection" |
+
+## Progressive Loading Strategy
+
+1. **Phase 1** — `loadTree()` calls `getRootItems()`, roots appear in UI immediately
+2. **Phase 2** — `_loadChildrenRecursively()` fires in background for each collection
+   - Each collection gets flagged in `loadingChildrenIds[]`
+   - `AdbTreeFolder.vue` shows spinner while loading
+   - Sub-collections trigger their own fetch recursively
+   - All siblings at same depth load in parallel via `Promise.all`
+
+## Auto-Reorder Strategy
+
+`_syncOrderedCollectionItems(collection, force?)` is called automatically after:
+- `updateCollectionItems()` — DnD reorder (calls with `force=true`)
+- `addItemToCollection()` — new item added
+- `deleteItem()` — item removed from ordered collection
+- `toggleCollectionOrder()` — order enabled
+- `updateRootItems()` — item moved from collection to root
+
+**Normal mode** (`force=false`): diffs each item's position against its index + 1, then calls `updateCollectionItemPosition()` only for changed ones.
+
+**Force mode** (`force=true`): always calls `updateCollectionItemPosition()` for every item regardless of current position. Used after DnD reorder (`updateCollectionItems`) because positions are pre-assigned in `.map()` before the sync runs, so a plain diff would find nothing to persist.
+
+## Cross-Collection DnD API Calls
+
+`updateCollectionItems()` distinguishes three cases via `oldParentId` (returned by `_detachItem`):
+
+- `oldParentId === collection.id` → item stayed in same collection → no API calls (reorder only)
+- `oldParentId` is different ID → cross-collection move → `removeItemFromCollection(old)` + `addItemToCollection(new)` + reorder old parent
+- `oldParentId === null` → root-to-collection move → `addItemToCollection(new)`
+
+## Running
+
+| Command | Adapter | Backend needed? |
+|---|---|---|
+| `npm run dev` | `AdbApiService` (real HTTP) | Yes |
+| `npm run dev:dummy` | `DevAdbApiService` (logs + seed data) | No |

--- a/frontend/src/feature/aufgabendatenbank/frontend-preparation.md
+++ b/frontend/src/feature/aufgabendatenbank/frontend-preparation.md
@@ -68,6 +68,10 @@ exerciseStore.ts  (depends on ApiAdapter interface)
 | `DELETE /api/items/{id}` | `deleteItem(id)` | Cascade delete |
 | `PUT /api/collections/{id}` | `updateCollection(id, { order })` | Single endpoint for both on/off |
 | `PUT /api/collection/{id}/items/{itemId}` | `updateCollectionItemPosition(id, itemId, pos)` | Note singular "collection" |
+| `GET /api/items/{itemId}/contents` | `getContents(itemId)` | Returns all content blocks for an item |
+| `POST /api/items/{itemId}/contents` | `createContent(itemId, payload)` | Creates a new content block |
+| `PUT /api/contents/{id}` | `updateContent(contentId, payload)` | Updates a content block's fields |
+| `DELETE /api/contents/{id}` | `deleteContent(contentId)` | Deletes a content block |
 
 ## Progressive Loading Strategy
 
@@ -99,9 +103,19 @@ exerciseStore.ts  (depends on ApiAdapter interface)
 - `oldParentId` is different ID → cross-collection move → `removeItemFromCollection(old)` + `addItemToCollection(new)` + reorder old parent
 - `oldParentId === null` → root-to-collection move → `addItemToCollection(new)`
 
-## Running
+## Item Content Sync
 
-| Command | Adapter | Backend needed? |
+Content CRUD follows the same fire-and-forget pattern as item/collection mutations:
+
+| Store Action | API Call | Frequency |
 |---|---|---|
-| `npm run dev` | `AdbApiService` (real HTTP) | Yes |
-| `npm run dev:dummy` | `DevAdbApiService` (logs + seed data) | No |
+| `addContentToSelectedItem()` | `adapter.createContent(itemId, payload)` | On user click (add button) |
+| `removeContentFromSelectedItem(index)` | `adapter.deleteContent(contentId)` | On user click (delete X button) |
+| `updateContentText(index, text)` | `adapter.updateContent(contentId, payload)` | On every keystroke (`@input`) |
+| `updateContentPurpose(index, purpose)` | `adapter.updateContent(contentId, payload)` | On every keystroke (`@input`) |
+
+All four fire the API call after applying the local state change, using `.catch(this._notifyError)` per the standard pattern. Text and purpose updates sync on every keystroke (no debounce) to match the direct fire-and-forget convention used elsewhere — the backend is expected to handle frequent PATCH-like updates gracefully.
+
+Content IDs are generated locally (`'content-' + timestamp`) for create, identical to the `createItem` / `createCollection` pattern. The backend-assigned ID from the response is ignored (fire-and-forget).
+
+## Running

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFolder.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFolder.vue
@@ -91,7 +91,19 @@
       </v-list-item>
     </template>
     <div class="folder-children">
-      <slot />
+      <div
+        v-if="isLoading"
+        class="loading-spinner"
+      >
+        <v-progress-circular
+          indeterminate
+          size="16"
+          width="2"
+          color="#007fd4"
+        />
+        <span class="loading-text">Laden...</span>
+      </div>
+      <slot v-else />
     </div>
   </v-list-group>
 
@@ -102,7 +114,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import AdbDeleteDialog from '@/feature/aufgabendatenbank/editor/components/AdbDeleteDialog.vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
 import type { Collection } from '@/lib/types'
@@ -124,6 +136,9 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits(['toggle-expand'])
+
+/** True while this collection's children are being fetched in the background. */
+const isLoading = computed(() => store.loadingChildrenIds.includes(props.element.id))
 
 /** Mark as hovered and auto-expand after 800ms.
  *  The delay prevents flickering when dragging quickly past a node. */
@@ -266,5 +281,18 @@ const onSelect = () => {
 .drop-target {
   background-color: rgba(0, 127, 212, 0.1);
   box-shadow: inset 0 0 0 1px #007fd4;
+}
+
+.loading-spinner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px 8px 48px;
+  color: #888;
+  font-size: 12px;
+}
+
+.loading-text {
+  user-select: none;
 }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,6 +11,15 @@ import router from "./router";
 import { registerPlugins } from "./plugins";
 import vuetify from "./plugins/vuetify";
 
+// API adapter selection
+// - npm run dev          → AdbApiService (real HTTP, expects backend at /api)
+// - npm run dev:dummy    → DevAdbApiService (logs requests, uses seed dummy data)
+import { setApiAdapter } from "@/stores/exerciseStore";
+import adbApi from "@/feature/aufgabendatenbank/adbApi.service";
+import devAdbApi from "@/feature/aufgabendatenbank/dev-adb-api.service";
+const adapter = import.meta.env.VITE_ADB_API_MODE === "dummy" ? devAdbApi : adbApi;
+setApiAdapter(adapter);
+
 const pinia = createPinia();
 const app = createApp(App);
 registerPlugins();

--- a/frontend/src/services/exerciseApiService.ts
+++ b/frontend/src/services/exerciseApiService.ts
@@ -2,7 +2,23 @@ import axios, { type AxiosInstance } from 'axios'
 import type { Item, Collection, CollectionItem, Content } from '@/lib/types'
 
 /**
- * ## Adb API Service
+ * @deprecated
+ *
+ * This service is superseded by the new {@link AdbApiService}
+ * (`src/feature/aufgabendatenbank/adbApi.service.ts`) which follows the
+ * updated API contract defined in `frontend/frontend-backend-communication.md`.
+ *
+ * Key differences:
+ * - Paths changed for several endpoints (e.g. `/api/items/root?=true` instead of `/api/items?root=true`)
+ * - New endpoints added (`PUT /collections/{id}/order`, `POST /items/{id}/collection`, etc.)
+ * - The new service is part of the feature module (`src/feature/aufgabendatenbank/`)
+ *   and implements the {@link ApiAdapter} interface for clean dependency inversion.
+ *
+ * This file is kept for reference only and will be removed once migration is complete.
+ */
+
+/**
+ * ## ExerciseApiService (deprecated)
  *
  * Geplante REST-Kommunikation zwischen Frontend und Spring-Boot-Backend.
  * Der Service bildet alle aktuellen Operationen aus `useAdbActions` auf API-Aufrufe ab.

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import { dummyData } from '@/feature/aufgabendatenbank/dummy-data'
 import { validateTreeData } from '@/feature/aufgabendatenbank/validation'
 import { useNotificationStore } from '@/stores/useNotificationStore'
 import {
@@ -7,42 +6,108 @@ import {
   type Collection,
   type CollectionItem,
   type TreeItem,
+  type Content,
   getInnerItem,
   isCollection as checkIsCollection,
   isCollectionItem
 } from '@/lib/types'
+import type {
+  ApiAdapter,
+  ItemDTO,
+  ContentDTO,
+  CollectionItemDTO
+} from '@/feature/aufgabendatenbank/api-adapter.types'
 
-interface State {
-  rootItems: Item[]
-  selectedItem: TreeItem | null
+// ── Adapter injection ─────────────────────────────────────────────────────────
+
+let _adapter: ApiAdapter | null = null
+
+/**
+ * Inject the API adapter into the exercise store.
+ * Must be called before `useExerciseStore()` is invoked.
+ */
+export function setApiAdapter(adapter: ApiAdapter): void {
+  _adapter = adapter
 }
 
+// ── DTO → Store type mappers ──────────────────────────────────────────────────
+
+function toContent(dto: ContentDTO): Content {
+  return {
+    id: dto.id,
+    license: dto.license,
+    contentType: dto.contentType,
+    author: dto.author,
+    tags: [],
+    purpose: dto.purpose,
+    jsonContent: dto.jsonContent as Record<string, any>,
+    blobContent: dto.blobContent
+  }
+}
+
+function toItem(dto: ItemDTO): Item {
+  return {
+    id: dto.id,
+    item_type: dto.item_type,
+    author: dto.author,
+    representationTemplate: dto.representationTemplate ?? null,
+    license: dto.license ?? null,
+    tags: [],
+    validators: [],
+    modifiers: [],
+    rootItemId: dto.rootItemId ?? null,
+    contents: (dto.contents ?? []).map(toContent),
+    items: dto.items?.map(toCollectionItem),
+    order: dto.order
+  }
+}
+
+function toCollectionItem(dto: CollectionItemDTO): CollectionItem {
+  return {
+    id: dto.id,
+    collectionId: dto.collectionId,
+    item: toItem(dto.item),
+    position: dto.position
+  }
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+interface ExerciseState {
+  rootItems: Item[]
+  selectedItem: TreeItem | null
+  loading: boolean
+  error: string | null
+  loadingChildrenIds: string[]
+}
+
+// ── Store ─────────────────────────────────────────────────────────────────────
+
 export const useExerciseStore = defineStore('exercise', {
-  state: (): State => ({
-    rootItems: [...dummyData.rootItems],
-    selectedItem: null
+  state: (): ExerciseState => ({
+    rootItems: [],
+    selectedItem: null,
+    loading: false,
+    error: null,
+    loadingChildrenIds: []
   }),
 
   getters: {
-    /** The raw Item in the selected tree node (unwraps CollectionItem if needed). */
     selectedInnerItem: (state): Item | null => {
       if (!state.selectedItem) return null
       return getInnerItem(state.selectedItem)
     },
 
-    /** Whether the selected tree node is a Collection. */
     isCollectionSelected(): boolean {
       const inner = this.selectedInnerItem
       return inner ? checkIsCollection(inner) : false
     },
 
-    /** The selected Collection, or null if none or not a Collection. */
     selectedCollection(): Collection | null {
       const inner = this.selectedInnerItem
       return inner && checkIsCollection(inner) ? (inner as Collection) : null
     },
 
-    /** Whether the selected collection is ordered (children have sequential positions). */
     isOrdered(): boolean {
       const coll = this.selectedCollection
       return coll ? coll.order === true : false
@@ -50,22 +115,96 @@ export const useExerciseStore = defineStore('exercise', {
   },
 
   actions: {
-    /** Select a tree node as the active/editor target. */
+    // ── Notifications ─────────────────────────────────────────────────────────
+
+    /** Push an API error string to the global notification store. */
+    _notifyError(e: unknown) {
+      const notifStore = useNotificationStore()
+      notifStore.push(String(e), 'error', 8000)
+    },
+
+    // ── Initialisation (progressive loading) ──────────────────────────────────
+
+    /**
+     * Load the exercise tree progressively.
+     *
+     * Phase 1: `getRootItems()` — roots appear in the UI immediately.
+     * Phase 2: `_loadChildrenRecursively()` — each collection's children
+     * load in the background with a per-node spinner in the tree view.
+     */
+    async loadTree() {
+      this.loading = true
+      this.error = null
+      try {
+        const dtos = await _adapter!.getRootItems()
+        this.rootItems = dtos.map(toItem)
+        // Fire background recursive loading — no await so UI shows roots now
+        this._loadChildrenRecursively(this.rootItems)
+      } catch (e) {
+        this.error = String(e)
+        this._notifyError(e)
+      } finally {
+        this.loading = false
+      }
+    },
+
+    /**
+     * Recursively load children for every collection in `items`.
+     *
+     * Each collection is flagged in `loadingChildrenIds` while its
+     * children are being fetched. Sub-collections inside the loaded
+     * children trigger their own fetch. All siblings at the same depth
+     * load in parallel.
+     */
+    async _loadChildrenRecursively(items: Item[]) {
+      const promises = items
+        .filter((item) => item.item_type === 'collection' || checkIsCollection(item))
+        .map(async (item) => {
+          const collection = item as Collection
+          this.loadingChildrenIds = [...this.loadingChildrenIds, collection.id]
+          try {
+            const dtos = await _adapter!.getCollectionItems(collection.id)
+            collection.items = dtos.map(toCollectionItem)
+            // Recurse into sub-collections
+            await this._loadChildrenRecursively(collection.items.map((ci) => ci.item))
+          } catch (e) {
+            this._notifyError(e)
+          } finally {
+            this.loadingChildrenIds = this.loadingChildrenIds.filter((id) => id !== collection.id)
+          }
+        })
+      await Promise.all(promises)
+    },
+
+    // ── Selection ─────────────────────────────────────────────────────────────
+
     selectItem(item: TreeItem) {
       this.selectedItem = item
     },
 
-    /** Toggle a collection's `order` flag and reassign/clear positions on its children. */
+    /**
+     * Toggle a collection's `order` flag.
+     *
+     * Positions are KEPT in the data when order toggles off (the UI
+     * simply hides them). When enabling, items without a position get
+     * one assigned.
+     */
     toggleCollectionOrder(collection: Collection) {
       collection.order = !collection.order
-      collection.items.forEach((item, index) => {
-        item.position = collection.order ? index + 1 : null
-      })
+      if (collection.order) {
+        collection.items.forEach((item, index) => {
+          if (item.position == null) {
+            item.position = index + 1
+          }
+        })
+      }
+      _adapter?.updateCollection(collection.id, { order: collection.order })
+        .catch((e) => this._notifyError(e))
+      this._syncOrderedCollectionItems(collection)
     },
 
-    // ── Content Actions ──
+    // ── Content Actions ───────────────────────────────────────────────────────
 
-    /** Add a new empty content block to the selected item. */
     addContentToSelectedItem() {
       const inner = this.selectedInnerItem
       if (!inner) return
@@ -82,44 +221,60 @@ export const useExerciseStore = defineStore('exercise', {
       })
     },
 
-    /** Remove a content block at the given index. */
     removeContentFromSelectedItem(index: number) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
       inner.contents.splice(index, 1)
     },
 
-    /** Update the text of a content block at the given index. */
     updateContentText(index: number, text: string) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
       inner.contents[index].jsonContent.text = text
     },
 
-    /** Update the purpose of a content block at the given index. */
     updateContentPurpose(index: number, purpose: string) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
       inner.contents[index].purpose = purpose
     },
 
-    // ── helpers ──
+    // ── Tree helpers ──
 
     /**
      * Remove an item from all collections and from rootItems.
-     * @param excludeId - If set, this ID is not removed from rootItems (to preserve the parent).
+     * @returns The ID of the parent collection the item was removed from, or null.
      */
-    _detachItem(itemId: string, excludeId?: string) {
+    _detachItem(itemId: string, excludeId?: string): string | null {
+      let parentId: string | null = null
       const removeFromCollections = (collections: Collection[]) => {
         collections.forEach((coll) => {
+          const hadItem = coll.items.some((ci) => ci.item.id === itemId)
+          if (hadItem) parentId = coll.id
           coll.items = coll.items.filter((ci) => ci.item.id !== itemId)
           const nested = coll.items.map((ci) => ci.item).filter(checkIsCollection)
           if (nested.length > 0) removeFromCollections(nested)
         })
       }
-      removeFromCollections(this.rootItems.filter(checkIsCollection))
-      // Keep excludeId around (the parent) so moving inside the same parent doesn't remove it
+      removeFromCollections(this.rootItems.filter(checkIsCollection) as Collection[])
       this.rootItems = this.rootItems.filter((ri) => ri.id !== itemId || ri.id === excludeId)
+      return parentId
+    },
+
+    /**
+     * Walk the tree to find a collection by ID.
+     */
+    _findCollectionById(id: string, items?: Item[]): Collection | null {
+      const searchItems = items ?? this.rootItems
+      for (const item of searchItems) {
+        if (item.id === id && checkIsCollection(item)) return item as Collection
+        if (checkIsCollection(item)) {
+          const coll = item as Collection
+          const found = this._findCollectionById(id, coll.items.map((ci) => ci.item))
+          if (found) return found
+        }
+      }
+      return null
     },
 
     /** Build a minimal Item object with a unique ID and single Content block. */
@@ -150,17 +305,47 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
+    /**
+     * After a mutation to an ordered collection, diff the current
+     * positions against their expected sequential order and push
+     * any changes to the API.
+     *
+     * Only fires when `collection.order === true`.
+     */
+    _syncOrderedCollectionItems(collection: Collection) {
+      if (!collection.order || !_adapter) return
+      collection.items.forEach((item, index) => {
+        const expected = index + 1
+        if (item.position !== expected) {
+          _adapter!.updateCollectionItemPosition(collection.id, item.id, expected)
+            .catch((e) => this._notifyError(e))
+          item.position = expected
+        }
+      })
+    },
+
     // ── CRUD Actions ──
 
-    /** Create a new exercise item and optionally append it to rootItems. */
     createItem(rootItemId: string | null = null, addToRoot = true): Item {
       const item = this._createItemData(rootItemId)
       if (addToRoot) this.rootItems.push(item)
+      _adapter?.createItem({
+        item_type: item.item_type,
+        author: item.author,
+        rootItemId: item.rootItemId ?? null,
+        contents: item.contents.map((c) => ({
+          license: c.license,
+          contentType: c.contentType,
+          author: c.author,
+          purpose: c.purpose,
+          jsonContent: c.jsonContent as Record<string, unknown>,
+          blobContent: c.blobContent
+        }))
+      }).catch((e) => this._notifyError(e))
       this.validate()
       return item
     },
 
-    /** Create a new empty collection and push it to rootItems. */
     createCollection(): Collection {
       const now = Date.now().toString()
       const collection: Collection = {
@@ -188,11 +373,23 @@ export const useExerciseStore = defineStore('exercise', {
         order: false
       }
       this.rootItems.push(collection)
+      _adapter?.createCollection({
+        item_type: 'collection',
+        author: collection.author,
+        contents: collection.contents.map((c) => ({
+          license: c.license,
+          contentType: c.contentType,
+          author: c.author,
+          purpose: c.purpose,
+          jsonContent: c.jsonContent as Record<string, unknown>,
+          blobContent: c.blobContent
+        })),
+        order: false
+      }).catch((e) => this._notifyError(e))
       this.validate()
       return collection
     },
 
-    /** Create a new exercise item and add it to a collection, assigning position if ordered. */
     addItemToCollection(collection: Collection): CollectionItem {
       const rootId = collection.rootItemId ?? collection.id
       const item = this.createItem(rootId, false)
@@ -203,28 +400,34 @@ export const useExerciseStore = defineStore('exercise', {
         position: collection.order ? collection.items.length + 1 : null
       }
       collection.items.push(collectionItem)
+      _adapter?.addItemToCollection(collection.id, item.id)
+        .catch((e) => this._notifyError(e))
+      this._syncOrderedCollectionItems(collection)
       this.validate()
       return collectionItem
     },
 
-    /** Convert a plain Item into a Collection by setting item_type and adding children arrays. */
     makeItemACollection(item: Item): Collection {
       if (checkIsCollection(item)) return item as Collection
       item.item_type = 'collection'
       item.items = []
       item.order = false
+      _adapter?.convertItemToCollection(item.id)
+        .catch((e) => this._notifyError(e))
       this.validate()
       return item as Collection
     },
 
-    /**
-     * Delete an item and remove it from any collection it belongs to.
-     */
     deleteItem(itemToDelete: Item) {
       const itemId = itemToDelete.id
-      this._detachItem(itemId)
+      const parentId = this._detachItem(itemId)
       if (this.selectedItem && getInnerItem(this.selectedItem).id === itemId) {
         this.selectedItem = null
+      }
+      _adapter?.deleteItem(itemId).catch((e) => this._notifyError(e))
+      if (parentId) {
+        const parent = this._findCollectionById(parentId)
+        if (parent) this._syncOrderedCollectionItems(parent)
       }
       this.validate()
     },
@@ -237,39 +440,48 @@ export const useExerciseStore = defineStore('exercise', {
 
     // ── DnD / Reorder Actions ──
 
-    /**
-     * Replace a collection's children with a reordered/dragged set.
-     * Detaches items that moved into this collection from elsewhere.
-     */
     updateCollectionItems(collection: Collection, newItems: TreeItem[]) {
       collection.items = newItems.map((item, index) => {
         const inner = getInnerItem(item)
-        // Items dragged in from elsewhere need to leave their old parent first
         if (inner.id !== collection.id) {
-          this._detachItem(inner.id, collection.id)
+          const oldParentId = this._detachItem(inner.id, collection.id)
+          // Cross-collection move: notify backend
+          if (oldParentId && oldParentId !== collection.id) {
+            _adapter?.removeItemFromCollection(oldParentId, inner.id)
+              .catch((e) => this._notifyError(e))
+            // Reorder the source collection if it was ordered
+            const oldParent = this._findCollectionById(oldParentId)
+            if (oldParent) this._syncOrderedCollectionItems(oldParent)
+          }
+          _adapter?.addItemToCollection(collection.id, inner.id)
+            .catch((e) => this._notifyError(e))
         }
-        // Set rootItemId to the root owner of this tree
         inner.rootItemId = collection.rootItemId ?? collection.id
         if (isCollectionItem(item)) {
-          return { ...item, collectionId: collection.id, position: collection.order ? index + 1 : null }
+          return { ...item, collectionId: collection.id, position: collection.order ? index + 1 : null } as CollectionItem
         }
         return {
           id: 'coll-item-' + Date.now().toString() + '-' + index,
           collectionId: collection.id,
           item: inner,
           position: collection.order ? index + 1 : null
-        }
+        } as CollectionItem
       })
+      this._syncOrderedCollectionItems(collection)
       this.validate()
     },
 
-    /**
-     * Replace rootItems after a top-level DnD reorder.
-     */
     updateRootItems(newItems: TreeItem[]) {
       const mapped = newItems.map((item) => {
         const inner = getInnerItem(item)
-        this._detachItem(inner.id)
+        const parentId = this._detachItem(inner.id)
+        // Moved from a collection to root: notify backend
+        if (parentId) {
+          _adapter?.removeItemFromCollection(parentId, inner.id)
+            .catch((e) => this._notifyError(e))
+          const oldParent = this._findCollectionById(parentId)
+          if (oldParent) this._syncOrderedCollectionItems(oldParent)
+        }
         return inner as Item
       })
       this.rootItems = mapped
@@ -278,9 +490,6 @@ export const useExerciseStore = defineStore('exercise', {
 
     // ── Validation ──
 
-    /**
-     * Run tree validation and push any issues to the global notification store.
-     */
     validate() {
       const issues = validateTreeData(this.rootItems)
       if (issues.length === 0) return

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -209,7 +209,7 @@ export const useExerciseStore = defineStore('exercise', {
       const inner = this.selectedInnerItem
       if (!inner) return
       const now = Date.now().toString()
-      inner.contents.push({
+      const content: Content = {
         id: 'content-' + now,
         license: null,
         contentType: 'text',
@@ -218,25 +218,56 @@ export const useExerciseStore = defineStore('exercise', {
         purpose: 'Neuer Inhalt',
         jsonContent: { text: '' },
         blobContent: ''
-      })
+      }
+      inner.contents.push(content)
+      _adapter?.createContent(inner.id, {
+        license: content.license,
+        contentType: content.contentType,
+        author: content.author,
+        purpose: content.purpose,
+        jsonContent: content.jsonContent as Record<string, unknown>,
+        blobContent: content.blobContent
+      }).catch((e) => this._notifyError(e))
     },
 
     removeContentFromSelectedItem(index: number) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
+      const removedId = inner.contents[index].id
       inner.contents.splice(index, 1)
+      if (removedId) {
+        _adapter?.deleteContent(removedId).catch((e) => this._notifyError(e))
+      }
     },
 
     updateContentText(index: number, text: string) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
-      inner.contents[index].jsonContent.text = text
+      const content = inner.contents[index]
+      content.jsonContent.text = text
+      _adapter?.updateContent(content.id ?? '', {
+        license: content.license,
+        contentType: content.contentType,
+        author: content.author,
+        purpose: content.purpose,
+        jsonContent: content.jsonContent as Record<string, unknown>,
+        blobContent: content.blobContent
+      }).catch((e) => this._notifyError(e))
     },
 
     updateContentPurpose(index: number, purpose: string) {
       const inner = this.selectedInnerItem
       if (!inner || !inner.contents[index]) return
-      inner.contents[index].purpose = purpose
+      const content = inner.contents[index]
+      content.purpose = purpose
+      _adapter?.updateContent(content.id ?? '', {
+        license: content.license,
+        contentType: content.contentType,
+        author: content.author,
+        purpose: content.purpose,
+        jsonContent: content.jsonContent as Record<string, unknown>,
+        blobContent: content.blobContent
+      }).catch((e) => this._notifyError(e))
     },
 
     // ── Tree helpers ──

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -312,11 +312,19 @@ export const useExerciseStore = defineStore('exercise', {
      *
      * Only fires when `collection.order === true`.
      */
-    _syncOrderedCollectionItems(collection: Collection) {
+    /**
+     * Persist positions for an ordered collection.
+     *
+     * @param collection - The collection to sync.
+     * @param force - When `true`, call the API for every item regardless
+     * of whether its local position already matches. Used after DnD reorder
+     * where positions are pre-set in `.map()` but still need to be persisted.
+     */
+    _syncOrderedCollectionItems(collection: Collection, force = false) {
       if (!collection.order || !_adapter) return
       collection.items.forEach((item, index) => {
         const expected = index + 1
-        if (item.position !== expected) {
+        if (force || item.position !== expected) {
           _adapter!.updateCollectionItemPosition(collection.id, item.id, expected)
             .catch((e) => this._notifyError(e))
           item.position = expected
@@ -445,16 +453,22 @@ export const useExerciseStore = defineStore('exercise', {
         const inner = getInnerItem(item)
         if (inner.id !== collection.id) {
           const oldParentId = this._detachItem(inner.id, collection.id)
-          // Cross-collection move: notify backend
-          if (oldParentId && oldParentId !== collection.id) {
-            _adapter?.removeItemFromCollection(oldParentId, inner.id)
+          if (oldParentId) {
+            if (oldParentId !== collection.id) {
+              // Cross-collection move: remove from source, add to target
+              _adapter?.removeItemFromCollection(oldParentId, inner.id)
+                .catch((e) => this._notifyError(e))
+              _adapter?.addItemToCollection(collection.id, inner.id)
+                .catch((e) => this._notifyError(e))
+              const oldParent = this._findCollectionById(oldParentId)
+              if (oldParent) this._syncOrderedCollectionItems(oldParent)
+            }
+            // oldParentId === collection.id → item stayed, skip API (reorder only)
+          } else {
+            // Root-to-collection move: add to target
+            _adapter?.addItemToCollection(collection.id, inner.id)
               .catch((e) => this._notifyError(e))
-            // Reorder the source collection if it was ordered
-            const oldParent = this._findCollectionById(oldParentId)
-            if (oldParent) this._syncOrderedCollectionItems(oldParent)
           }
-          _adapter?.addItemToCollection(collection.id, inner.id)
-            .catch((e) => this._notifyError(e))
         }
         inner.rootItemId = collection.rootItemId ?? collection.id
         if (isCollectionItem(item)) {
@@ -467,7 +481,7 @@ export const useExerciseStore = defineStore('exercise', {
           position: collection.order ? index + 1 : null
         } as CollectionItem
       })
-      this._syncOrderedCollectionItems(collection)
+      this._syncOrderedCollectionItems(collection, true)
       this.validate()
     },
 


### PR DESCRIPTION
# Frontend überarbeitet: Aufgaben organisieren und bearbeiten

Der gesamte Bereich „Aufgabendatenbank" im Frontend wurde von Grund auf neu strukturiert.
Ziel war es, die Kommunikation zwischen Frontend und Backend sauber zu regeln und eine
solide Grundlage für die nächsten Schritte zu schaffen.

## Was wurde gemacht?

**Alte Logik abgelöst** – Der bisherige „ExerciseApiService" ist nicht mehr in Gebrauch.
An seine Stelle tritt ein klares System: Eine einheitliche Schnittstelle (ApiAdapter) mit
zwei Varianten – einer echten für den Produktivbetrieb und einer Entwickler-Variante, die
ohne Backend funktioniert und Testdaten nutzt.

**Die wichtigsten Neuerungen:**

- **Aufbau der Baumansicht** – Beim Laden erscheinen zuerst die obersten Ebenen, die
  restlichen Daten werden im Hintergrund geholt. Während des Ladevorgangs wird ein
  Ladesymbol angezeigt.
- **Verschieben per Drag & Drop** – Aufgaben können innerhalb einer Sammlung neu
  angeordnet, in andere Sammlungen verschoben oder wieder freigestellt werden.
  Das Frontend kümmert sich dabei um die nötigen Anfragen an das Backend.
- **Sortierung ein- und ausschalten** – Sammlungen können wahlweise geordnet oder
  ungeordnet sein. Wird die Sortierung eingeschaltet, erhalten alle Aufgaben eine
  Position. Beim Ausschalten bleiben die Positionsdaten erhalten, werden aber
  ausgeblendet. Nach jeder Änderung werden die Positionen automatisch mit dem
  Backend abgeglichen.
- **Inhalte von Aufgaben verwalten** – Aufgaben bestehen aus einem oder mehreren
  Inhaltsblöcken (z. B. Aufgabenstellung, Hinweis, Lösung). Diese lassen sich jetzt
  hinzufügen, bearbeiten und löschen – jede Änderung wird direkt an das Backend
  gesendet.

**Neue Dateien (4):**
- Schnittstellendefinition und Datenstrukturen
- Produktiver HTTP-Dienst für die echte API
- Entwickler-Dienst mit Testdaten
- Konfiguration für den Entwicklermodus

**Angepasst (7 Dateien):**
- Zentrale Verwaltung (Speicher) für den Aufgabendatenbank-Bereich
- Einstiegspunkt der Anwendung (Auswahl des passenden Dienstes)
- Zwei Oberflächenkomponenten (Aufruf der Baumansicht, Ladesymbol)
- Alte Logik als veraltet markiert
- Paketverwaltung um Entwicklerskript erweitert
- Dokumentation der Änderungen

## Wie wird getestet?

- **`npm run dev`** – normaler Betrieb mit laufendem Backend
- **`npm run dev:dummy`** – Entwicklermodus ohne Backend, mit Testdaten. LOGS schauen!

Beide Modi verhalten sich aus Nutzersicht gleich. Unterschiede gibt es nur bei der
Datenquelle und den Konsolenausgaben.
