### PR TITLE
feat(adb): Horizontale Varianten ueber root_item_id anzeigen

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
+
+# Multipart upload limits (Bilder, PDFs)
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -95,9 +95,7 @@ export class AdbApiService implements ApiAdapter {
   async uploadBlob(contentId: string, file: File): Promise<void> {
     const formData = new FormData()
     formData.append('file', file)
-    await this.http.post(`/contents/${contentId}/blob`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' }
-    })
+    await this.http.post(`/contents/${contentId}/blob`, formData)
   }
 
   getBlobUrl(contentId: string): string {

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -16,8 +16,7 @@ export class AdbApiService implements ApiAdapter {
 
   constructor(baseURL = '/api') {
     this.http = axios.create({
-      baseURL,
-      headers: { 'Content-Type': 'application/json' }
+      baseURL
     })
   }
 

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -92,6 +92,18 @@ export class AdbApiService implements ApiAdapter {
     await this.http.delete(`/contents/${contentId}`)
   }
 
+  async uploadBlob(contentId: string, file: File): Promise<void> {
+    const formData = new FormData()
+    formData.append('file', file)
+    await this.http.post(`/contents/${contentId}/blob`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  }
+
+  getBlobUrl(contentId: string): string {
+    return `/api/contents/${contentId}/blob`
+  }
+
   async loadFullTree(): Promise<ItemDTO[]> {
     return this.getRootItems()
   }

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -95,6 +95,11 @@ export class AdbApiService implements ApiAdapter {
   async loadFullTree(): Promise<ItemDTO[]> {
     return this.getRootItems()
   }
+
+  async getItemsByRootId(rootItemId: string): Promise<ItemDTO[]> {
+    const { data } = await this.http.get<ItemDTO[]>('/items', { params: { rootItemId } })
+    return data
+  }
 }
 
 export default new AdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -116,5 +116,9 @@ export interface ApiAdapter {
 
   deleteContent(contentId: string): Promise<void>
 
+  uploadBlob(contentId: string, file: File): Promise<void>
+
+  getBlobUrl(contentId: string): string
+
   loadFullTree(): Promise<ItemDTO[]>
 }

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -108,8 +108,6 @@ export interface ApiAdapter {
 
   updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void>
 
-  uploadBlob(contentId: string, file: File): Promise<void>
-
   getContents(itemId: string): Promise<ContentDTO[]>
 
   createContent(itemId: string, payload: CreateContentPayload): Promise<ContentDTO>

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -108,6 +108,8 @@ export interface ApiAdapter {
 
   updateCollectionItemPosition(collectionId: string, itemId: string, position: number): Promise<void>
 
+  uploadBlob(contentId: string, file: File): Promise<void>
+
   getContents(itemId: string): Promise<ContentDTO[]>
 
   createContent(itemId: string, payload: CreateContentPayload): Promise<ContentDTO>

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -117,4 +117,6 @@ export interface ApiAdapter {
   deleteContent(contentId: string): Promise<void>
 
   loadFullTree(): Promise<ItemDTO[]>
+
+  getItemsByRootId(rootItemId: string): Promise<ItemDTO[]>
 }

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -328,6 +328,14 @@ export class DevAdbApiService implements ApiAdapter {
     log('GET', '/api/items?root=true (loadFullTree)')
     return dummyData.rootItems.map(toDTO)
   }
+
+  async getItemsByRootId(rootItemId: string): Promise<ItemDTO[]> {
+    log('GET', `/api/items?rootItemId=${rootItemId}`)
+    return dummyData.rootItems
+      .flatMap(item => item.items ?? [])
+      .filter(ci => ci.item.rootItemId === rootItemId)
+      .map(ci => toDTO(ci.item))
+  }
 }
 
 export default new DevAdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -324,6 +324,18 @@ export class DevAdbApiService implements ApiAdapter {
     log('DELETE', `/api/contents/${contentId}`)
   }
 
+  async uploadBlob(contentId: string, file: File): Promise<void> {
+    log('POST', `/api/contents/${contentId}/blob`, {
+      fileName: file.name,
+      fileSize: file.size,
+      fileType: file.type
+    })
+  }
+
+  getBlobUrl(contentId: string): string {
+    return `/api/contents/${contentId}/blob`
+  }
+
   async loadFullTree(): Promise<ItemDTO[]> {
     log('GET', '/api/items?root=true (loadFullTree)')
     return dummyData.rootItems.map(toDTO)

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -116,6 +116,8 @@ function deleteSelectedItem() {
   padding: 28px 36px;
   font-size: 13px;
   color: #cccccc;
+  overflow-y: auto;
+  max-height: 100%;
 }
 
 .editor-header-row {

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -48,6 +48,8 @@
 
         <AdbContentList />
 
+        <AdbVariantsPanel />
+
         <p class="text-caption text-grey">
           ID: {{ store.selectedItem.id }}
         </p>
@@ -62,6 +64,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import AdbContentList from './components/AdbContentList.vue'
+import AdbVariantsPanel from './components/AdbVariantsPanel.vue'
 import AdbDeleteDialog from './components/AdbDeleteDialog.vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
 

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
@@ -42,6 +42,7 @@
     <div class="card-divider" />
 
     <div class="card-body">
+      <!-- Text content (jsonContent.text) -->
       <div
         v-if="!editingText"
         class="content-text"
@@ -69,6 +70,84 @@
           @keydown.escape="editingText = false"
         />
       </div>
+
+      <!-- Blob section -->
+      <div class="blob-section">
+        <!-- Image preview -->
+        <div
+          v-if="isImageDisplayable"
+          class="blob-preview"
+        >
+          <img
+            :src="blobSrc"
+            alt="Vorschau"
+            class="preview-img"
+            @error="onImgError"
+          >
+          <div class="blob-actions">
+            <a
+              :href="blobSrc"
+              download
+              class="blob-action-link"
+            >
+              <v-icon
+                icon="mdi-download"
+                size="16"
+              />
+              Herunterladen
+            </a>
+          </div>
+        </div>
+
+        <!-- PDF / unknown binary download link -->
+        <div
+          v-if="hasBlob && !isImageDisplayable"
+          class="blob-download"
+        >
+          <v-icon
+            icon="mdi-file-pdf-box"
+            size="32"
+            color="#f40"
+          />
+          <span class="blob-filename">PDF-Datei</span>
+          <a
+            :href="blobSrc"
+            target="_blank"
+            class="blob-action-link"
+          >
+            <v-icon
+              icon="mdi-download"
+              size="16"
+            />
+            Öffnen / Herunterladen
+          </a>
+        </div>
+
+        <!-- Upload button (when no blob) -->
+        <div
+          v-if="!hasBlob"
+          class="blob-upload"
+        >
+          <input
+            ref="fileInput"
+            type="file"
+            accept="image/png,image/jpeg,application/pdf"
+            class="file-input-hidden"
+            @change="onFileSelected"
+          >
+          <button
+            type="button"
+            class="upload-btn"
+            @click="triggerFilePicker"
+          >
+            <v-icon
+              icon="mdi-upload"
+              size="18"
+            />
+            <span>Datei hochladen (PNG, JPEG, PDF)</span>
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -76,9 +155,11 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import type { Content } from '@/lib/types'
+import { useExerciseStore } from '@/stores/exerciseStore'
 
 const props = defineProps<{
   content: Content
+  index: number
 }>()
 
 const emit = defineEmits<{
@@ -87,12 +168,37 @@ const emit = defineEmits<{
   delete: []
 }>()
 
+const store = useExerciseStore()
+
 const editingText = ref(false)
 const editingPurpose = ref(false)
 const purposeInput = ref<HTMLInputElement | null>(null)
 const textInput = ref<HTMLTextAreaElement | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+const imageError = ref(false)
 
 const displayText = computed(() => props.content.jsonContent?.text ?? '')
+
+const hasBlob = computed(() => {
+  return !!(props.content.blobMimeType || props.content.blobContent)
+})
+
+const isImage = computed(() => {
+  if (props.content.blobMimeType) {
+    return props.content.blobMimeType.startsWith('image/')
+  }
+  return false
+})
+
+const isImageDisplayable = computed(() => {
+  return hasBlob.value && isImage.value && !imageError.value
+})
+
+const blobSrc = computed(() => {
+  if (!props.content.id) return ''
+  const base = window.location.origin
+  return `${base}/api/contents/${props.content.id}/blob`
+})
 
 function onPurposeInput(e: Event) {
   emit('update:purpose', (e.target as HTMLInputElement).value)
@@ -116,6 +222,22 @@ function startEditText() {
       el.setSelectionRange(el.value.length, el.value.length)
     }
   })
+}
+
+function triggerFilePicker() {
+  fileInput.value?.click()
+}
+
+function onFileSelected(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  store.uploadBlob(props.index, file)
+  input.value = ''
+}
+
+function onImgError() {
+  imageError.value = true
 }
 </script>
 
@@ -284,6 +406,93 @@ function startEditText() {
 
   &::placeholder {
     color: #666;
+  }
+}
+
+/* ── Blob section ── */
+
+.blob-section {
+  margin-top: 8px;
+}
+
+.blob-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  background: #1e1e1e;
+  border-radius: 12px;
+}
+
+.preview-img {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+.blob-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.blob-action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #007fd4;
+  text-decoration: none;
+  font-size: 13px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  transition: background 0.15s;
+
+  &:hover {
+    background: rgba(0, 127, 212, 0.1);
+  }
+}
+
+.blob-download {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: #1e1e1e;
+  border-radius: 12px;
+}
+
+.blob-filename {
+  font-size: 13px;
+  color: #ccc;
+  flex: 1;
+}
+
+.blob-upload {
+  margin-top: 4px;
+}
+
+.file-input-hidden {
+  display: none;
+}
+
+.upload-btn {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #888;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 12px;
+  border: 1px dashed #555;
+  transition: all 0.15s;
+
+  &:hover {
+    color: #ccc;
+    border-color: #888;
+    background: rgba(255, 255, 255, 0.03);
   }
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
@@ -183,11 +183,12 @@ const hasBlob = computed(() => {
   return !!(props.content.blobMimeType || props.content.blobContent)
 })
 
+const detectedMimeType = computed(() => {
+  return props.content.blobMimeType || props.content.contentType || ''
+})
+
 const isImage = computed(() => {
-  if (props.content.blobMimeType) {
-    return props.content.blobMimeType.startsWith('image/')
-  }
-  return false
+  return detectedMimeType.value.startsWith('image/')
 })
 
 const isImageDisplayable = computed(() => {

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
@@ -4,6 +4,7 @@
       v-for="(content, index) in contents"
       :key="content.id ?? index"
       :content="content"
+      :index="index"
       @update:text="(val) => store.updateContentText(index, val)"
       @update:purpose="(val) => store.updateContentPurpose(index, val)"
       @delete="store.removeContentFromSelectedItem(index)"

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
@@ -1,0 +1,202 @@
+<template>
+  <div
+    v-if="store.variants.length > 0"
+    class="variants-panel"
+  >
+    <div class="variants-header">
+      <span class="variants-title">Varianten</span>
+      <span class="variants-count">{{ store.variants.length }}</span>
+    </div>
+
+    <div class="variants-grid">
+      <div
+        v-for="(variant, vi) in store.variants"
+        :key="variant.id"
+        class="variant-card"
+      >
+        <div class="variant-card-header">
+          <span class="variant-label">
+            Variante {{ vi + 1 }}
+          </span>
+          <span class="variant-id">ID: {{ variant.id?.slice(0, 8) }}...</span>
+        </div>
+
+        <div class="variant-contents">
+          <AdbContentEditor
+            v-for="(content, ci) in variant.contents"
+            :key="content.id ?? ci"
+            :content="content"
+            :index="ci"
+            @update:text="(val) => store.updateVariantText(vi, ci, val)"
+            @update:purpose="(val) => store.updateVariantPurpose(vi, ci, val)"
+            @delete="store.removeVariantContent(vi, ci)"
+          />
+
+          <button
+            type="button"
+            class="add-content-btn"
+            @click="store.addVariantContent(vi)"
+          >
+            <span class="btn-inner">
+              <v-icon
+                icon="mdi-plus"
+                size="16"
+              />
+              <span>Inhalt hinzufügen</span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <button
+      type="button"
+      class="add-variant-btn"
+      @click="onAddVariant"
+    >
+      <span class="btn-inner">
+        <v-icon
+          icon="mdi-plus"
+          size="18"
+        />
+        <span>Variante erstellen</span>
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useExerciseStore } from '@/stores/exerciseStore'
+import AdbContentEditor from './AdbContentEditor.vue'
+
+const store = useExerciseStore()
+
+function onAddVariant() {
+  const inner = store.selectedInnerItem
+  if (!inner) return
+  const baseId = inner.rootItemId ?? inner.id
+  store.createVariant(baseId)
+}
+</script>
+
+<style scoped lang="scss">
+.variants-panel {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #333;
+}
+
+.variants-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.variants-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #ccc;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.variants-count {
+  background: #3c3c3c;
+  color: #999;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.variants-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.variant-card {
+  background: #252526;
+  border: 1px solid #3c3c3c;
+  border-radius: 16px;
+  padding: 12px;
+}
+
+.variant-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #333;
+}
+
+.variant-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #aaa;
+}
+
+.variant-id {
+  font-size: 10px;
+  color: #555;
+  font-family: monospace;
+}
+
+.variant-contents {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.add-content-btn {
+  all: unset;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 16px;
+  color: #666;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px dashed #444;
+  margin-top: 4px;
+
+  &:hover {
+    color: #aaa;
+    border-color: #666;
+    background: rgba(255, 255, 255, 0.02);
+  }
+}
+
+.add-variant-btn {
+  all: unset;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 22px;
+  color: #888;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px dashed #555;
+
+  &:hover {
+    color: #ccc;
+    border-color: #888;
+    background: rgba(255, 255, 255, 0.02);
+  }
+}
+
+.btn-inner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+</style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
@@ -1,6 +1,8 @@
 <template>
+  <!-- Auch bei 0 Varianten zeigen, sonst lässt sich die erste Variante nie
+       anlegen (der Erstell-Button hing vorher selbst am v-if). -->
   <div
-    v-if="store.variants.length > 0"
+    v-if="store.selectedInnerItem && !store.isCollectionSelected"
     class="variants-panel"
   >
     <div class="variants-header">

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbConfirmDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbConfirmDialog.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-dialog
+    v-model="internalVisible"
+    max-width="420"
+    persistent
+  >
+    <v-card class="confirm-dialog-card">
+      <v-card-title class="confirm-dialog-title">
+        {{ title }}
+      </v-card-title>
+      <v-card-text class="confirm-dialog-text">
+        {{ message }}
+      </v-card-text>
+      <v-card-actions class="confirm-dialog-actions">
+        <v-spacer />
+        <v-btn
+          variant="text"
+          class="cancel-btn"
+          @click="onCancel"
+        >
+          Abbrechen
+        </v-btn>
+        <v-btn
+          variant="flat"
+          class="confirm-btn"
+          @click="onConfirm"
+        >
+          {{ confirmLabel }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  visible: boolean
+  title?: string
+  message?: string
+  confirmLabel?: string
+}>(), {
+  title: 'Bestätigen',
+  message: 'Möchten Sie fortfahren?',
+  confirmLabel: 'Fortfahren'
+})
+
+const emit = defineEmits<{
+  (e: 'update:visible', val: boolean): void
+  (e: 'confirm'): void
+  (e: 'cancel'): void
+}>()
+
+const internalVisible = computed({
+  get: () => props.visible,
+  set: (val) => emit('update:visible', val)
+})
+
+function onConfirm() {
+  emit('confirm')
+  emit('update:visible', false)
+}
+
+function onCancel() {
+  emit('cancel')
+  emit('update:visible', false)
+}
+</script>
+
+<style scoped lang="scss">
+.confirm-dialog-card {
+  background-color: #1e1e1e !important;
+  color: #cccccc !important;
+  border: 1px solid #333;
+}
+
+.confirm-dialog-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e0e0e0;
+  padding: 20px 24px 8px;
+}
+
+.confirm-dialog-text {
+  font-size: 13px;
+  color: #999;
+  padding: 8px 24px 16px;
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.confirm-dialog-actions {
+  padding: 8px 16px 16px;
+}
+
+.cancel-btn {
+  color: #999 !important;
+  text-transform: none;
+  font-weight: 500;
+
+  &:hover {
+    color: #ccc !important;
+  }
+}
+
+.confirm-btn {
+  background-color: #007fd4 !important;
+  color: #fff !important;
+  text-transform: none;
+  font-weight: 600;
+
+  &:hover {
+    background-color: #1a9aff !important;
+  }
+}
+</style>

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFile.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFile.vue
@@ -81,11 +81,20 @@
     v-model:visible="showDeleteDialog"
     @confirm="onDeleteConfirmed"
   />
+
+  <AdbConfirmDialog
+    v-model:visible="showConvertDialog"
+    title="In Kollektion umwandeln"
+    :message="convertMessage"
+    confirm-label="Fortfahren"
+    @confirm="onConvertConfirmed"
+  />
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import AdbDeleteDialog from '@/feature/aufgabendatenbank/editor/components/AdbDeleteDialog.vue'
+import AdbConfirmDialog from './AdbConfirmDialog.vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
 import { getInnerItem, type TreeItem } from '@/lib/types'
 
@@ -94,6 +103,16 @@ const store = useExerciseStore()
 /** Whether a drag is currently hovering this item. */
 const isDragOver = ref(false)
 const showDeleteDialog = ref(false)
+const showConvertDialog = ref(false)
+const variantCount = ref(0)
+
+/** Warnung vor dem Umwandeln: Varianten (horizontal) werden danach nicht mehr genutzt. */
+const convertMessage = computed(() => {
+  const n = variantCount.value
+  const hat = n === 1 ? 'besitzt 1 Variante' : `besitzt ${n} Varianten`
+  const werden = n === 1 ? 'wird diese Variante' : 'werden diese Varianten'
+  return `Diese Aufgabe ${hat}.\n\nNach der Umwandlung in eine Kollektion ${werden} nicht mehr verwendet.\n\nMöchten Sie fortfahren?`
+})
 
 const props = defineProps<{
   element: TreeItem
@@ -115,10 +134,24 @@ const onClick = () => {
   store.selectItem(props.element)
 }
 
-/** Convert the underlying item into a Collection via the store. */
-const onMakeCollection = () => {
+/**
+ * Convert the underlying item into a Collection.
+ * Hat die Aufgabe Varianten, erst warnen (die horizontale Varianten-Beziehung
+ * geht dabei verloren) und auf Bestätigung warten.
+ */
+const onMakeCollection = async () => {
   const item = getInnerItem(props.element)
-  store.makeItemACollection(item)
+  const count = await store.getVariantCount(item.id)
+  if (count > 0) {
+    variantCount.value = count
+    showConvertDialog.value = true
+  } else {
+    store.makeItemACollection(item)
+  }
+}
+
+const onConvertConfirmed = () => {
+  store.makeItemACollection(getInnerItem(props.element))
 }
 
 /** Show confirmation dialog before deleting. */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface Content {
   purpose: string
   jsonContent: Record<string, any>
   blobContent: string
+  blobMimeType?: string
 }
 
 export interface Item {

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -109,6 +109,7 @@ function toCollectionItem(dto: CollectionItemDTO): CollectionItem {
 interface ExerciseState {
   rootItems: Item[]
   selectedItem: TreeItem | null
+  variants: Item[]
   loading: boolean
   loadingContent: boolean
   error: string | null
@@ -121,6 +122,7 @@ export const useExerciseStore = defineStore('exercise', {
   state: (): ExerciseState => ({
     rootItems: [],
     selectedItem: null,
+    variants: [],
     loading: false,
     loadingContent: false,
     error: null,
@@ -221,8 +223,13 @@ export const useExerciseStore = defineStore('exercise', {
 
     selectItem(item: TreeItem) {
       this.selectedItem = item
+      this.variants = []
       const inner = getInnerItem(item)
       this.loadItemContent(inner.id)
+      if (!checkIsCollection(inner)) {
+        const baseId = inner.rootItemId ?? inner.id
+        this.loadVariants(baseId)
+      }
     },
 
     async loadItemContent(itemId: string) {
@@ -347,6 +354,147 @@ export const useExerciseStore = defineStore('exercise', {
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).catch((e) => this._notifyError(e))
+    },
+
+    async uploadBlob(index: number, file: File) {
+      const inner = this.selectedInnerItem
+      if (!inner || !inner.contents[index]) return
+      const content = inner.contents[index]
+      const contentId = content.id
+      if (!contentId) return
+      try {
+        await _adapter!.uploadBlob(contentId, file)
+        content.blobMimeType = file.type
+        content.blobContent = file.type.startsWith('image/') ? '(image)' : '(binary)'
+      } catch (e) {
+        this._notifyError(e)
+      }
+    },
+
+    // ── Variants ────────────────────────────────────────────────────────────────
+
+    async loadVariants(baseItemId: string) {
+      this.variants = []
+      try {
+        const dtos = await _adapter!.getItemsByRootId(baseItemId)
+        this.variants = dtos.map(toItem)
+        await Promise.all(this.variants.map(async (v) => {
+          const contentDtos = await _adapter!.getContents(v.id)
+          if (contentDtos.length > 0) {
+            v.contents = contentDtos.map(toFullContent)
+          }
+        }))
+      } catch (e) {
+        this._notifyError(e)
+      }
+    },
+
+    async createVariant(baseItemId: string) {
+      const variant = this._createItemData(baseItemId)
+      this.variants.push(variant)
+      try {
+        const dto = await _adapter!.createItem({
+          authorId: SEED_AUTHOR_ID,
+          licenseId: SEED_LICENSE_ID,
+          itemTypeId: SEED_ITEM_TYPE_ID,
+          rootItemId: baseItemId
+        })
+        variant.id = dto.itemId
+        if (variant.contents.length > 0) {
+          const contentDto = await _adapter!.createContent(dto.itemId, {
+            licenseId: SEED_LICENSE_ID,
+            itemContentTypeId: SEED_CONTENT_TYPE_ID,
+            authorId: SEED_AUTHOR_ID,
+            purpose: variant.contents[0].purpose,
+            jsonSerializedContent: JSON.stringify(variant.contents[0].jsonContent)
+          })
+          if (contentDto && variant.contents[0]) {
+            variant.contents[0].id = contentDto.itemContentId
+          }
+        }
+      } catch (e) {
+        this._notifyError(e)
+        this.variants = this.variants.filter((v) => v !== variant)
+      }
+    },
+
+    updateVariantText(variantIndex: number, contentIndex: number, text: string) {
+      const variant = this.variants[variantIndex]
+      if (!variant || !variant.contents[contentIndex]) return
+      const content = variant.contents[contentIndex]
+      content.jsonContent.text = text
+      _adapter?.updateContent(content.id ?? '', {
+        licenseId: SEED_LICENSE_ID,
+        itemContentTypeId: SEED_CONTENT_TYPE_ID,
+        authorId: SEED_AUTHOR_ID,
+        purpose: content.purpose,
+        jsonSerializedContent: JSON.stringify(content.jsonContent)
+      }).catch((e) => this._notifyError(e))
+    },
+
+    updateVariantPurpose(variantIndex: number, contentIndex: number, purpose: string) {
+      const variant = this.variants[variantIndex]
+      if (!variant || !variant.contents[contentIndex]) return
+      const content = variant.contents[contentIndex]
+      content.purpose = purpose
+      _adapter?.updateContent(content.id ?? '', {
+        licenseId: SEED_LICENSE_ID,
+        itemContentTypeId: SEED_CONTENT_TYPE_ID,
+        authorId: SEED_AUTHOR_ID,
+        purpose: content.purpose,
+        jsonSerializedContent: JSON.stringify(content.jsonContent)
+      }).catch((e) => this._notifyError(e))
+    },
+
+    addVariantContent(variantIndex: number) {
+      const variant = this.variants[variantIndex]
+      if (!variant) return
+      const now = Date.now().toString()
+      const content: Content = {
+        id: 'content-' + now,
+        license: null,
+        contentType: 'text',
+        author: variant.author ?? 'author',
+        tags: [],
+        purpose: 'Neuer Inhalt',
+        jsonContent: { text: '' },
+        blobContent: ''
+      }
+      variant.contents.push(content)
+      _adapter?.createContent(variant.id, {
+        licenseId: SEED_LICENSE_ID,
+        itemContentTypeId: SEED_CONTENT_TYPE_ID,
+        authorId: SEED_AUTHOR_ID,
+        purpose: content.purpose,
+        jsonSerializedContent: JSON.stringify(content.jsonContent)
+      }).then((dto) => {
+        if (dto) content.id = dto.itemContentId
+      }).catch((e) => this._notifyError(e))
+    },
+
+    removeVariantContent(variantIndex: number, contentIndex: number) {
+      const variant = this.variants[variantIndex]
+      if (!variant || !variant.contents[contentIndex]) return
+      const removedId = variant.contents[contentIndex].id
+      variant.contents.splice(contentIndex, 1)
+      if (removedId) {
+        _adapter?.deleteContent(removedId).catch((e) => this._notifyError(e))
+      }
+    },
+
+    async uploadVariantBlob(variantIndex: number, contentIndex: number, file: File) {
+      const variant = this.variants[variantIndex]
+      if (!variant || !variant.contents[contentIndex]) return
+      const content = variant.contents[contentIndex]
+      const contentId = content.id
+      if (!contentId) return
+      try {
+        await _adapter!.uploadBlob(contentId, file)
+        content.blobMimeType = file.type
+        content.blobContent = file.type.startsWith('image/') ? '(image)' : '(binary)'
+      } catch (e) {
+        this._notifyError(e)
+      }
     },
 
     // ── Tree helpers ──

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -19,12 +19,13 @@ import type {
   CollectionItemDTO
 } from '@/feature/aufgabendatenbank/api-adapter.types'
 
-// ── Seed-UUIDs (müssen mit database/init/init.sql übereinstimmen) ─────────────
+// ── Default-UUIDs (identisch mit database/init/init.sql) ───────────────────────
+// Werden genutzt, solange der Benutzer im UI keine eigene Auswahl trifft.
 
-const SEED_AUTHOR_ID = 'd0000000-0000-0000-0000-000000000001'
-const SEED_LICENSE_ID = 'b0000000-0000-0000-0000-000000000001'
-const SEED_ITEM_TYPE_ID = 'e0000000-0000-0000-0000-000000000001'
-const SEED_CONTENT_TYPE_ID = 'a0000000-0000-0000-0000-000000000003'
+const DEFAULT_AUTHOR_ID = 'd0000000-0000-0000-0000-000000000001'
+const DEFAULT_LICENSE_ID = 'b0000000-0000-0000-0000-000000000001'
+const DEFAULT_ITEM_TYPE_ID = 'e0000000-0000-0000-0000-000000000001'
+const DEFAULT_CONTENT_TYPE_ID = 'a0000000-0000-0000-0000-000000000003'
 
 // ── Adapter injection ─────────────────────────────────────────────────────────
 
@@ -113,6 +114,10 @@ interface ExerciseState {
   loadingContent: boolean
   error: string | null
   loadingChildrenIds: string[]
+  selectedAuthorId: string | null
+  selectedLicenseId: string | null
+  selectedItemTypeId: string | null
+  selectedContentTypeId: string | null
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -124,10 +129,19 @@ export const useExerciseStore = defineStore('exercise', {
     loading: false,
     loadingContent: false,
     error: null,
-    loadingChildrenIds: []
+    loadingChildrenIds: [],
+    selectedAuthorId: null,
+    selectedLicenseId: null,
+    selectedItemTypeId: null,
+    selectedContentTypeId: null
   }),
 
   getters: {
+    authorId: (state): string => state.selectedAuthorId ?? DEFAULT_AUTHOR_ID,
+    licenseId: (state): string => state.selectedLicenseId ?? DEFAULT_LICENSE_ID,
+    itemTypeId: (state): string => state.selectedItemTypeId ?? DEFAULT_ITEM_TYPE_ID,
+    contentTypeId: (state): string => state.selectedContentTypeId ?? DEFAULT_CONTENT_TYPE_ID,
+
     selectedInnerItem: (state): Item | null => {
       if (!state.selectedItem) return null
       return getInnerItem(state.selectedItem)
@@ -301,9 +315,9 @@ export const useExerciseStore = defineStore('exercise', {
       }
       inner.contents.push(content)
       _adapter?.createContent(inner.id, {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId: this.licenseId,
+        itemContentTypeId: this.contentTypeId,
+        authorId: this.authorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).then((dto) => {
@@ -327,9 +341,9 @@ export const useExerciseStore = defineStore('exercise', {
       const content = inner.contents[index]
       content.jsonContent.text = text
       _adapter?.updateContent(content.id ?? '', {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId: this.licenseId,
+        itemContentTypeId: this.contentTypeId,
+        authorId: this.authorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).catch((e) => this._notifyError(e))
@@ -341,9 +355,9 @@ export const useExerciseStore = defineStore('exercise', {
       const content = inner.contents[index]
       content.purpose = purpose
       _adapter?.updateContent(content.id ?? '', {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId: this.licenseId,
+        itemContentTypeId: this.contentTypeId,
+        authorId: this.authorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).catch((e) => this._notifyError(e))
@@ -464,9 +478,9 @@ export const useExerciseStore = defineStore('exercise', {
       const item = this._createItemData(rootItemId)
       if (addToRoot) this.rootItems.push(item)
       _adapter?.createItem({
-        authorId: SEED_AUTHOR_ID,
-        licenseId: SEED_LICENSE_ID,
-        itemTypeId: SEED_ITEM_TYPE_ID,
+        authorId: this.authorId,
+        licenseId: this.licenseId,
+        itemTypeId: this.itemTypeId,
         rootItemId: item.rootItemId ?? null
       }).then((dto) => {
         if (dto) {
@@ -474,9 +488,9 @@ export const useExerciseStore = defineStore('exercise', {
           onCreated?.(dto.itemId)
           if (item.contents.length > 0) {
             _adapter?.createContent(dto.itemId, {
-              licenseId: SEED_LICENSE_ID,
-              itemContentTypeId: SEED_CONTENT_TYPE_ID,
-              authorId: SEED_AUTHOR_ID,
+              licenseId: this.licenseId,
+              itemContentTypeId: this.contentTypeId,
+              authorId: this.authorId,
               purpose: item.contents[0].purpose,
               jsonSerializedContent: JSON.stringify(item.contents[0].jsonContent)
             }).then((contentDto) => {
@@ -512,9 +526,9 @@ export const useExerciseStore = defineStore('exercise', {
       // (POST /items → POST /items/{id}/collection). So taucht die Kollektion
       // beim Neuladen über GET /items?root=true wieder auf.
       _adapter?.createItem({
-        authorId: SEED_AUTHOR_ID,
-        licenseId: SEED_LICENSE_ID,
-        itemTypeId: SEED_ITEM_TYPE_ID,
+        authorId: this.authorId,
+        licenseId: this.licenseId,
+        itemTypeId: this.itemTypeId,
         rootItemId: null
       })
         .then((dto) => {
@@ -556,13 +570,47 @@ export const useExerciseStore = defineStore('exercise', {
       item.item_type = 'collection'
       item.items = []
       item.order = false
+      this.validate()
       _adapter?.convertItemToCollection(item.id)
         .then((dto) => {
           if (dto) item.collectionId = dto.collectionId ?? null
+          this._loadVariantsAsChildren(item as Collection)
         })
         .catch((e) => this._notifyError(e))
-      this.validate()
       return item as Collection
+    },
+
+    _loadVariantsAsChildren(collection: Collection) {
+      const variants = this._findItemsByRootId(collection.id)
+      for (const variant of variants) {
+        this._detachItem(variant.id)
+        const collectionItem: CollectionItem = {
+          id: 'coll-item-' + Date.now() + '-' + variant.id,
+          collectionId: collection.id,
+          item: variant,
+          position: collection.order ? collection.items.length + 1 : null
+        }
+        collection.items.push(collectionItem)
+        if (collection.collectionId) {
+          _adapter?.addItemToCollection(collection.collectionId, variant.id)
+            .catch((e) => this._notifyError(e))
+        }
+      }
+      this.validate()
+    },
+
+    _findItemsByRootId(rootId: string, items?: Item[]): Item[] {
+      const searchItems = items ?? this.rootItems
+      const result: Item[] = []
+      for (const item of searchItems) {
+        if (item.rootItemId === rootId) {
+          result.push(item)
+        }
+        if (item.items) {
+          result.push(...this._findItemsByRootId(rootId, item.items.map((ci) => ci.item)))
+        }
+      }
+      return result
     },
 
     deleteItem(itemToDelete: Item) {

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -387,6 +387,21 @@ export const useExerciseStore = defineStore('exercise', {
 
     // ── Variants ────────────────────────────────────────────────────────────────
 
+    /**
+     * Zählt die Varianten eines Items (Items mit root_item_id === itemId),
+     * ohne den State zu verändern. Für die Warnung vor dem Umwandeln
+     * in eine Collection.
+     */
+    async getVariantCount(itemId: string): Promise<number> {
+      try {
+        const dtos = await _adapter!.getItemsByRootId(itemId)
+        return dtos.length
+      } catch (e) {
+        this._notifyError(e)
+        return 0
+      }
+    },
+
     async loadVariants(baseItemId: string) {
       this.variants = []
       try {
@@ -706,43 +721,9 @@ export const useExerciseStore = defineStore('exercise', {
       _adapter?.convertItemToCollection(item.id)
         .then((dto) => {
           if (dto) item.collectionId = dto.collectionId ?? null
-          this._loadVariantsAsChildren(item as Collection)
         })
         .catch((e) => this._notifyError(e))
       return item as Collection
-    },
-
-    _loadVariantsAsChildren(collection: Collection) {
-      const variants = this._findItemsByRootId(collection.id)
-      for (const variant of variants) {
-        this._detachItem(variant.id)
-        const collectionItem: CollectionItem = {
-          id: 'coll-item-' + Date.now() + '-' + variant.id,
-          collectionId: collection.id,
-          item: variant,
-          position: collection.order ? collection.items.length + 1 : null
-        }
-        collection.items.push(collectionItem)
-        if (collection.collectionId) {
-          _adapter?.addItemToCollection(collection.collectionId, variant.id)
-            .catch((e) => this._notifyError(e))
-        }
-      }
-      this.validate()
-    },
-
-    _findItemsByRootId(rootId: string, items?: Item[]): Item[] {
-      const searchItems = items ?? this.rootItems
-      const result: Item[] = []
-      for (const item of searchItems) {
-        if (item.rootItemId === rootId) {
-          result.push(item)
-        }
-        if (item.items) {
-          result.push(...this._findItemsByRootId(rootId, item.items.map((ci) => ci.item)))
-        }
-      }
-      return result
     },
 
     deleteItem(itemToDelete: Item) {

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -349,6 +349,21 @@ export const useExerciseStore = defineStore('exercise', {
       }).catch((e) => this._notifyError(e))
     },
 
+    async uploadBlob(index: number, file: File) {
+      const inner = this.selectedInnerItem
+      if (!inner || !inner.contents[index]) return
+      const content = inner.contents[index]
+      const contentId = content.id
+      if (!contentId) return
+      try {
+        await _adapter!.uploadBlob(contentId, file)
+        content.blobMimeType = file.type
+        content.blobContent = file.type.startsWith('image/') ? '(image)' : '(binary)'
+      } catch (e) {
+        this._notifyError(e)
+      }
+    },
+
     // ── Tree helpers ──
 
     /**


### PR DESCRIPTION
- getItemsByRootId im ApiAdapter-Interface + Implementierungen
- variants-State + loadVariants/createVariant im exerciseStore
- AdbVariantsPanel: Variantenkarten nebeneinander mit Content-Editoren
- selectItem lädt automatisch Varianten zur Basis-Aufgabe
- Varianten-Content bearbeitbar (updateVariantText/Purpose)