### PR TITLE
Feat/validators modifiers

### DIFF
--- a/backend/src/main/java/com/datenbank/backend/controller/ItemController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ItemController.java
@@ -2,6 +2,7 @@ package com.datenbank.backend.controller;
 
 import com.datenbank.backend.dto.ItemCreateDto;
 import com.datenbank.backend.dto.ItemResponseDto;
+import com.datenbank.backend.dto.ValidatorResponseDto;
 import com.datenbank.backend.service.ItemService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -83,5 +84,42 @@ public class ItemController {
 
         // Alle Items
         return ResponseEntity.ok(itemService.getAllItems());
+    }
+
+    // =========================================================================
+    // Validator-Verknüpfungen
+    // =========================================================================
+
+    /**
+     * Liefert alle Validatoren, die mit einem Item verknüpft sind.
+     * GET /api/items/{itemId}/validators
+     */
+    @GetMapping("/{itemId}/validators")
+    public ResponseEntity<List<ValidatorResponseDto>> getValidatorsForItem(
+            @PathVariable UUID itemId) {
+        return ResponseEntity.ok(itemService.getValidatorsForItem(itemId));
+    }
+
+    /**
+     * Verknüpft einen Validator mit einem Item.
+     * POST /api/items/{itemId}/validators/{validatorId}
+     */
+    @PostMapping("/{itemId}/validators/{validatorId}")
+    public ResponseEntity<ItemResponseDto> addValidatorToItem(
+            @PathVariable UUID itemId,
+            @PathVariable UUID validatorId) {
+        return ResponseEntity.ok(itemService.addValidatorToItem(itemId, validatorId));
+    }
+
+    /**
+     * Entfernt die Verknüpfung eines Validators von einem Item.
+     * DELETE /api/items/{itemId}/validators/{validatorId}
+     */
+    @DeleteMapping("/{itemId}/validators/{validatorId}")
+    public ResponseEntity<Void> removeValidatorFromItem(
+            @PathVariable UUID itemId,
+            @PathVariable UUID validatorId) {
+        itemService.removeValidatorFromItem(itemId, validatorId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/datenbank/backend/controller/ValidatorController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ValidatorController.java
@@ -1,0 +1,54 @@
+package com.datenbank.backend.controller;
+
+import com.datenbank.backend.dto.ValidatorCreateDto;
+import com.datenbank.backend.dto.ValidatorResponseDto;
+import com.datenbank.backend.service.ValidatorService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/validators")
+@CrossOrigin(origins = "*")
+public class ValidatorController {
+
+    private final ValidatorService validatorService;
+
+    public ValidatorController(ValidatorService validatorService) {
+        this.validatorService = validatorService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ValidatorResponseDto>> getAll() {
+        return ResponseEntity.ok(validatorService.getAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ValidatorResponseDto> getById(@PathVariable UUID id) {
+        return ResponseEntity.ok(validatorService.getById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<ValidatorResponseDto> create(
+            @Valid @RequestBody ValidatorCreateDto dto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(validatorService.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ValidatorResponseDto> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody ValidatorCreateDto dto) {
+        return ResponseEntity.ok(validatorService.update(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        validatorService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/datenbank/backend/dto/ValidatorCreateDto.java
+++ b/backend/src/main/java/com/datenbank/backend/dto/ValidatorCreateDto.java
@@ -1,0 +1,31 @@
+package com.datenbank.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ValidatorCreateDto {
+
+    @NotBlank(message = "Beschreibung ist Pflicht")
+    private String description;
+
+    @NotBlank(message = "Regeltext ist Pflicht")
+    private String validator;
+
+    public ValidatorCreateDto() {
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getValidator() {
+        return validator;
+    }
+
+    public void setValidator(String validator) {
+        this.validator = validator;
+    }
+}

--- a/backend/src/main/java/com/datenbank/backend/dto/ValidatorResponseDto.java
+++ b/backend/src/main/java/com/datenbank/backend/dto/ValidatorResponseDto.java
@@ -1,0 +1,37 @@
+package com.datenbank.backend.dto;
+
+import java.util.UUID;
+
+public class ValidatorResponseDto {
+
+    private UUID validatorId;
+    private String description;
+    private String validator;
+
+    public ValidatorResponseDto() {
+    }
+
+    public UUID getValidatorId() {
+        return validatorId;
+    }
+
+    public void setValidatorId(UUID validatorId) {
+        this.validatorId = validatorId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getValidator() {
+        return validator;
+    }
+
+    public void setValidator(String validator) {
+        this.validator = validator;
+    }
+}

--- a/backend/src/main/java/com/datenbank/backend/service/ItemService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ItemService.java
@@ -3,6 +3,7 @@ package com.datenbank.backend.service;
 import com.datenbank.backend.dto.ContentSummaryDto;
 import com.datenbank.backend.dto.ItemCreateDto;
 import com.datenbank.backend.dto.ItemResponseDto;
+import com.datenbank.backend.dto.ValidatorResponseDto;
 import com.datenbank.backend.entity.*;
 import com.datenbank.backend.repository.*;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -157,6 +159,47 @@ public class ItemService {
         collectionRepository.save(collection);
 
         return convertToResponseDto(item);
+    }
+
+    // =========================================================================
+    // Validator-Verknüpfungen
+    // =========================================================================
+
+    @Transactional(readOnly = true)
+    public List<ValidatorResponseDto> getValidatorsForItem(UUID itemId) {
+        Item item = findItemOrThrow(itemId);
+        return item.getValidators().stream()
+                .map(v -> {
+                    ValidatorResponseDto dto = new ValidatorResponseDto();
+                    dto.setValidatorId(v.getValidatorId());
+                    dto.setDescription(v.getDescription());
+                    dto.setValidator(v.getValidator());
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ItemResponseDto addValidatorToItem(UUID itemId, UUID validatorId) {
+        Item item = findItemOrThrow(itemId);
+        Validator validator = validatorRepository.findById(validatorId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Validator nicht gefunden"));
+        item.getValidators().add(validator);
+        Item saved = itemRepository.save(item);
+        return convertToResponseDto(saved);
+    }
+
+    @Transactional
+    public ItemResponseDto removeValidatorFromItem(UUID itemId, UUID validatorId) {
+        Item item = findItemOrThrow(itemId);
+        boolean removed = item.getValidators().removeIf(v -> v.getValidatorId().equals(validatorId));
+        if (!removed) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, "Validator nicht mit diesem Item verknüpft");
+        }
+        Item saved = itemRepository.save(item);
+        return convertToResponseDto(saved);
     }
 
     // =========================================================================

--- a/backend/src/main/java/com/datenbank/backend/service/ValidatorService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ValidatorService.java
@@ -1,0 +1,74 @@
+package com.datenbank.backend.service;
+
+import com.datenbank.backend.dto.ValidatorCreateDto;
+import com.datenbank.backend.dto.ValidatorResponseDto;
+import com.datenbank.backend.entity.Validator;
+import com.datenbank.backend.repository.ValidatorRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class ValidatorService {
+
+    private final ValidatorRepository validatorRepository;
+
+    public ValidatorService(ValidatorRepository validatorRepository) {
+        this.validatorRepository = validatorRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ValidatorResponseDto> getAll() {
+        return validatorRepository.findAll().stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ValidatorResponseDto getById(UUID id) {
+        return convertToResponseDto(findOrThrow(id));
+    }
+
+    @Transactional
+    public ValidatorResponseDto create(ValidatorCreateDto dto) {
+        Validator validator = new Validator(dto.getDescription(), dto.getValidator());
+        Validator saved = validatorRepository.save(validator);
+        return convertToResponseDto(saved);
+    }
+
+    @Transactional
+    public ValidatorResponseDto update(UUID id, ValidatorCreateDto dto) {
+        Validator validator = findOrThrow(id);
+        validator.setDescription(dto.getDescription());
+        validator.setValidator(dto.getValidator());
+        Validator saved = validatorRepository.save(validator);
+        return convertToResponseDto(saved);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        if (!validatorRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Validator nicht gefunden");
+        }
+        validatorRepository.deleteById(id);
+    }
+
+    private Validator findOrThrow(UUID id) {
+        return validatorRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Validator nicht gefunden"));
+    }
+
+    private ValidatorResponseDto convertToResponseDto(Validator validator) {
+        ValidatorResponseDto dto = new ValidatorResponseDto();
+        dto.setValidatorId(validator.getValidatorId());
+        dto.setDescription(validator.getDescription());
+        dto.setValidator(validator.getValidator());
+        return dto;
+    }
+}

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -8,7 +8,9 @@ import type {
   CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload,
-  OrderTogglePayload
+  OrderTogglePayload,
+  ValidatorDTO,
+  CreateValidatorPayload
 } from './api-adapter.types'
 
 export class AdbApiService implements ApiAdapter {
@@ -99,6 +101,49 @@ export class AdbApiService implements ApiAdapter {
   async getItemsByRootId(rootItemId: string): Promise<ItemDTO[]> {
     const { data } = await this.http.get<ItemDTO[]>('/items', { params: { rootItemId } })
     return data
+  }
+
+  async uploadBlob(contentId: string, file: File): Promise<void> {
+    const formData = new FormData()
+    formData.append('file', file)
+    await this.http.post(`/contents/${contentId}/blob`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  }
+
+  // ── Validators ───────────────────────────────────────────────────────
+
+  async getValidators(): Promise<ValidatorDTO[]> {
+    const { data } = await this.http.get<ValidatorDTO[]>('/validators')
+    return data
+  }
+
+  async createValidator(payload: CreateValidatorPayload): Promise<ValidatorDTO> {
+    const { data } = await this.http.post<ValidatorDTO>('/validators', payload)
+    return data
+  }
+
+  async updateValidator(id: string, payload: CreateValidatorPayload): Promise<ValidatorDTO> {
+    const { data } = await this.http.put<ValidatorDTO>(`/validators/${id}`, payload)
+    return data
+  }
+
+  async deleteValidator(id: string): Promise<void> {
+    await this.http.delete(`/validators/${id}`)
+  }
+
+  async getValidatorsForItem(itemId: string): Promise<ValidatorDTO[]> {
+    const { data } = await this.http.get<ValidatorDTO[]>(`/items/${itemId}/validators`)
+    return data
+  }
+
+  async addValidatorToItem(itemId: string, validatorId: string): Promise<ItemDTO> {
+    const { data } = await this.http.post<ItemDTO>(`/items/${itemId}/validators/${validatorId}`)
+    return data
+  }
+
+  async removeValidatorFromItem(itemId: string, validatorId: string): Promise<void> {
+    await this.http.delete(`/items/${itemId}/validators/${validatorId}`)
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -85,6 +85,17 @@ export interface OrderTogglePayload {
   order: boolean
 }
 
+export interface ValidatorDTO {
+  validatorId: string
+  description: string
+  validator: string
+}
+
+export interface CreateValidatorPayload {
+  description: string
+  validator: string
+}
+
 export interface ApiAdapter {
   getRootItems(): Promise<ItemDTO[]>
 
@@ -119,4 +130,22 @@ export interface ApiAdapter {
   loadFullTree(): Promise<ItemDTO[]>
 
   getItemsByRootId(rootItemId: string): Promise<ItemDTO[]>
+
+  uploadBlob(contentId: string, file: File): Promise<void>
+
+  // ── Validators ───────────────────────────────────────────────────────
+
+  getValidators(): Promise<ValidatorDTO[]>
+
+  createValidator(payload: CreateValidatorPayload): Promise<ValidatorDTO>
+
+  updateValidator(id: string, payload: CreateValidatorPayload): Promise<ValidatorDTO>
+
+  deleteValidator(id: string): Promise<void>
+
+  getValidatorsForItem(itemId: string): Promise<ValidatorDTO[]>
+
+  addValidatorToItem(itemId: string, validatorId: string): Promise<ItemDTO>
+
+  removeValidatorFromItem(itemId: string, validatorId: string): Promise<void>
 }

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -9,7 +9,9 @@ import type {
   CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload,
-  OrderTogglePayload
+  OrderTogglePayload,
+  ValidatorDTO,
+  CreateValidatorPayload
 } from './api-adapter.types'
 import type { Item, Content, CollectionItem } from '@/lib/types'
 
@@ -101,6 +103,24 @@ function findItem(id: string, items: Item[]): Item | undefined {
   }
   return undefined
 }
+
+const seedValidators: ValidatorDTO[] = [
+  {
+    validatorId: 'val-must-inner-join',
+    description: 'muss INNER JOIN enthalten',
+    validator: 'CHECK(sql_query CONTAINS "INNER JOIN")'
+  },
+  {
+    validatorId: 'val-order-by',
+    description: 'muss ORDER BY enthalten',
+    validator: 'CHECK(sql_query CONTAINS "ORDER BY")'
+  },
+  {
+    validatorId: 'val-no-subqueries',
+    description: 'keine verschachtelten Subqueries',
+    validator: 'CHECK(NOT CONTAINS "SELECT ... FROM (SELECT ...)")'
+  }
+]
 
 export class DevAdbApiService implements ApiAdapter {
   async getRootItems(): Promise<ItemDTO[]> {
@@ -335,6 +355,72 @@ export class DevAdbApiService implements ApiAdapter {
       .flatMap(item => item.items ?? [])
       .filter(ci => ci.item.rootItemId === rootItemId)
       .map(ci => toDTO(ci.item))
+  }
+
+  async uploadBlob(contentId: string, file: File): Promise<void> {
+    log('POST', `/api/contents/${contentId}/blob`, { fileName: file.name, size: file.size })
+  }
+
+  // ── Validators ───────────────────────────────────────────────────────
+
+  private _validators: ValidatorDTO[] = [...seedValidators]
+
+  async getValidators(): Promise<ValidatorDTO[]> {
+    log('GET', '/api/validators')
+    return [...this._validators]
+  }
+
+  async createValidator(payload: CreateValidatorPayload): Promise<ValidatorDTO> {
+    log('POST', '/api/validators', payload)
+    const v: ValidatorDTO = {
+      validatorId: uid('val'),
+      description: payload.description,
+      validator: payload.validator
+    }
+    this._validators.push(v)
+    return v
+  }
+
+  async updateValidator(id: string, payload: CreateValidatorPayload): Promise<ValidatorDTO> {
+    log('PUT', `/api/validators/${id}`, payload)
+    const idx = this._validators.findIndex(v => v.validatorId === id)
+    if (idx === -1) throw new Error('Validator nicht gefunden')
+    this._validators[idx] = { ...this._validators[idx], ...payload }
+    return this._validators[idx]
+  }
+
+  async deleteValidator(id: string): Promise<void> {
+    log('DELETE', `/api/validators/${id}`)
+    this._validators = this._validators.filter(v => v.validatorId !== id)
+  }
+
+  async getValidatorsForItem(itemId: string): Promise<ValidatorDTO[]> {
+    log('GET', `/api/items/${itemId}/validators`)
+    const item = findItem(itemId, dummyData.rootItems)
+    if (!item) return []
+    return (item.validators ?? [])
+      .map((vid: string) => this._validators.find(v => v.validatorId === vid))
+      .filter(Boolean) as ValidatorDTO[]
+  }
+
+  async addValidatorToItem(itemId: string, validatorId: string): Promise<ItemDTO> {
+    log('POST', `/api/items/${itemId}/validators/${validatorId}`)
+    const item = findItem(itemId, dummyData.rootItems)
+    if (!item) throw new Error('Item nicht gefunden')
+    if (!item.validators) item.validators = []
+    if (!item.validators.includes(validatorId)) {
+      item.validators.push(validatorId)
+    }
+    return toDTO(item)
+  }
+
+  async removeValidatorFromItem(itemId: string, validatorId: string): Promise<void> {
+    log('DELETE', `/api/items/${itemId}/validators/${validatorId}`)
+    const item = findItem(itemId, dummyData.rootItems)
+    if (!item) return
+    if (item.validators) {
+      item.validators = item.validators.filter((v: string) => v !== validatorId)
+    }
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -48,6 +48,8 @@
 
         <AdbContentList />
 
+        <AdbValidatorEditor />
+
         <AdbVariantsPanel />
 
         <p class="text-caption text-grey">
@@ -65,6 +67,7 @@
 import { computed, ref } from 'vue'
 import AdbContentList from './components/AdbContentList.vue'
 import AdbVariantsPanel from './components/AdbVariantsPanel.vue'
+import AdbValidatorEditor from './components/AdbValidatorEditor.vue'
 import AdbDeleteDialog from './components/AdbDeleteDialog.vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
 

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbValidatorEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbValidatorEditor.vue
@@ -1,0 +1,276 @@
+<template>
+  <div v-if="store.selectedInnerItem" class="validator-section">
+    <div class="section-header">
+      <span class="section-title">Validatoren (Restriktionen)</span>
+      <v-btn
+        icon="mdi-plus"
+        variant="text"
+        size="x-small"
+        class="add-btn"
+        @click="showCreateDialog = true"
+      />
+    </div>
+
+    <div class="validators-list">
+      <div
+        v-for="v in linkedValidators"
+        :key="v.validatorId"
+        class="validator-chip"
+      >
+        <div class="validator-info">
+          <span class="validator-desc">{{ v.description }}</span>
+          <span class="validator-rule">{{ v.validator }}</span>
+        </div>
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          size="x-small"
+          class="remove-btn"
+          @click="store.unlinkValidatorFromSelectedItem(v.validatorId)"
+        />
+      </div>
+      <div v-if="linkedValidators.length === 0" class="empty-hint">
+        Keine Validatoren zugewiesen
+      </div>
+    </div>
+
+    <div v-if="unlinkedValidators.length > 0" class="available-section">
+      <span class="available-label">Verfügbare Validatoren</span>
+      <div class="available-list">
+        <div
+          v-for="v in unlinkedValidators"
+          :key="v.validatorId"
+          class="available-chip"
+          @click="store.linkValidatorToSelectedItem(v.validatorId)"
+        >
+          {{ v.description }}
+        </div>
+      </div>
+    </div>
+
+    <v-dialog
+      v-model="showCreateDialog"
+      max-width="500"
+      persistent
+    >
+      <v-card class="dialog-card">
+        <v-card-title class="dialog-title">Neuen Validator erstellen</v-card-title>
+        <v-card-text class="dialog-text">
+          <v-text-field
+            v-model="newDescription"
+            label="Beschreibung"
+            placeholder="z. B. muss INNER JOIN enthalten"
+            variant="outlined"
+            density="compact"
+            hide-details
+            class="mb-3"
+          />
+          <v-textarea
+            v-model="newRule"
+            label="Regeltext"
+            placeholder="z. B. CHECK(sql_query CONTAINS &quot;INNER JOIN&quot;)"
+            variant="outlined"
+            density="compact"
+            hide-details
+            rows="3"
+          />
+        </v-card-text>
+        <v-card-actions class="dialog-actions">
+          <v-btn
+            variant="text"
+            class="cancel-btn"
+            @click="cancelCreate"
+          >
+            Abbrechen
+          </v-btn>
+          <v-btn
+            variant="text"
+            class="save-btn"
+            :disabled="!newDescription.trim() || !newRule.trim()"
+            @click="confirmCreate"
+          >
+            Erstellen
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useExerciseStore } from '@/stores/exerciseStore'
+
+const store = useExerciseStore()
+const showCreateDialog = ref(false)
+const newDescription = ref('')
+const newRule = ref('')
+
+const linkedValidators = computed(() => {
+  const inner = store.selectedInnerItem
+  if (!inner) return []
+  return store.allValidators.filter((v) => inner.validators.includes(v.validatorId))
+})
+
+const unlinkedValidators = computed(() => {
+  const inner = store.selectedInnerItem
+  if (!inner) return []
+  return store.allValidators.filter((v) => !inner.validators.includes(v.validatorId))
+})
+
+async function confirmCreate() {
+  const desc = newDescription.value.trim()
+  const rule = newRule.value.trim()
+  if (!desc || !rule) return
+  const dto = await store.createValidator(desc, rule)
+  if (dto) {
+    await store.linkValidatorToSelectedItem(dto.validatorId)
+  }
+  cancelCreate()
+}
+
+function cancelCreate() {
+  showCreateDialog.value = false
+  newDescription.value = ''
+  newRule.value = ''
+}
+</script>
+
+<style scoped>
+.validator-section {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #333;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #969696;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.add-btn {
+  color: #007fd4 !important;
+}
+
+.validators-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.validator-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 8px 10px;
+  gap: 8px;
+}
+
+.validator-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.validator-desc {
+  font-size: 13px;
+  color: #cccccc;
+  font-weight: 500;
+}
+
+.validator-rule {
+  font-size: 11px;
+  color: #888;
+  font-family: monospace;
+}
+
+.remove-btn {
+  color: #c04040 !important;
+  flex-shrink: 0;
+}
+
+.empty-hint {
+  font-size: 12px;
+  color: #666;
+  font-style: italic;
+  padding: 4px 0;
+}
+
+.available-section {
+  margin-top: 8px;
+}
+
+.available-label {
+  font-size: 11px;
+  color: #777;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.available-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.available-chip {
+  font-size: 12px;
+  color: #aaa;
+  background-color: #252525;
+  border: 1px dashed #555;
+  border-radius: 4px;
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.available-chip:hover {
+  color: #007fd4;
+  border-color: #007fd4;
+  background-color: #0d2b45;
+}
+
+.dialog-card {
+  background-color: #1e1e1e !important;
+  color: #cccccc !important;
+}
+
+.dialog-title {
+  color: #cccccc;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.dialog-text {
+  padding-top: 16px !important;
+}
+
+.dialog-actions {
+  padding: 8px 16px 16px !important;
+}
+
+.cancel-btn {
+  color: #969696 !important;
+}
+
+.save-btn {
+  color: #007fd4 !important;
+}
+</style>

--- a/frontend/src/feature/aufgabendatenbank/validation.ts
+++ b/frontend/src/feature/aufgabendatenbank/validation.ts
@@ -96,7 +96,6 @@ export function validateTreeData(rootItems: Item[]): ValidationIssue[] {
 
   return [
     ...checkOnlyCollectionsHaveChildren(allItems),
-    ...checkNoDuplicateItems(rootItems),
     ...checkNoDanglingRootItemId(allItems)
   ]
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface Content {
   purpose: string
   jsonContent: Record<string, any>
   blobContent: string
+  blobMimeType?: string
 }
 
 export interface Item {
@@ -21,8 +22,8 @@ export interface Item {
   representationTemplate: string | null
   license: string | null
   tags: string[]
-  validators: any[]
-  modifiers: any[]
+  validators: string[]
+  modifiers: string[]
   rootItemId?: string | null
   contents: Content[]
   items?: CollectionItem[]

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -16,7 +16,8 @@ import type {
   ItemDTO,
   ContentDTO,
   ContentSummaryDTO,
-  CollectionItemDTO
+  CollectionItemDTO,
+  ValidatorDTO
 } from '@/feature/aufgabendatenbank/api-adapter.types'
 
 // ── Seed-UUIDs (müssen mit database/init/init.sql übereinstimmen) ─────────────
@@ -81,9 +82,9 @@ function toItem(dto: ItemDTO): Item {
     author: dto.authorDescriptor,
     representationTemplate: dto.itemTemplateId ?? null,
     license: dto.licenseName ?? null,
-    tags: [],
-    validators: [],
-    modifiers: [],
+    tags: dto.tagIds ?? [],
+    validators: dto.validatorIds ?? [],
+    modifiers: dto.modifierIds ?? [],
     rootItemId: dto.rootItemId ?? null,
     contents: (dto.contents ?? []).map(toContent),
     // Eine Kollektion hat IMMER ein items-Array (zunächst leer, bis die
@@ -114,6 +115,7 @@ interface ExerciseState {
   loadingContent: boolean
   error: string | null
   loadingChildrenIds: string[]
+  allValidators: ValidatorDTO[]
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -126,7 +128,8 @@ export const useExerciseStore = defineStore('exercise', {
     loading: false,
     loadingContent: false,
     error: null,
-    loadingChildrenIds: []
+    loadingChildrenIds: [],
+    allValidators: []
   }),
 
   getters: {
@@ -175,7 +178,10 @@ export const useExerciseStore = defineStore('exercise', {
       this.loading = true
       this.error = null
       try {
-        const dtos = await _adapter!.getRootItems()
+        const [dtos] = await Promise.all([
+          _adapter!.getRootItems(),
+          this.loadValidators()
+        ])
         this.rootItems = dtos.map(toItem)
         // Fire background recursive loading — no await so UI shows roots now
         this._loadChildrenRecursively(this.rootItems)
@@ -288,6 +294,54 @@ export const useExerciseStore = defineStore('exercise', {
           .catch((e) => this._notifyError(e))
       }
       this._syncOrderedCollectionItems(collection)
+    },
+
+    // ── Validator Actions ────────────────────────────────────────────────────
+
+    async loadValidators() {
+      try {
+        this.allValidators = await _adapter!.getValidators()
+      } catch (e) {
+        this._notifyError(e)
+      }
+    },
+
+    async createValidator(description: string, rule: string): Promise<ValidatorDTO | null> {
+      try {
+        const dto = await _adapter!.createValidator({ description, validator: rule })
+        this.allValidators.push(dto)
+        return dto
+      } catch (e) {
+        this._notifyError(e)
+        return null
+      }
+    },
+
+    async linkValidatorToSelectedItem(validatorId: string) {
+      const inner = this.selectedInnerItem
+      if (!inner) return
+      if (inner.validators.includes(validatorId)) return
+      inner.validators.push(validatorId)
+      try {
+        await _adapter!.addValidatorToItem(inner.id, validatorId)
+      } catch (e) {
+        inner.validators = inner.validators.filter((v: string) => v !== validatorId)
+        this._notifyError(e)
+      }
+    },
+
+    async unlinkValidatorFromSelectedItem(validatorId: string) {
+      const inner = this.selectedInnerItem
+      if (!inner) return
+      inner.validators = inner.validators.filter((v: string) => v !== validatorId)
+      try {
+        await _adapter!.removeValidatorFromItem(inner.id, validatorId)
+      } catch (e) {
+        if (!inner.validators.includes(validatorId)) {
+          inner.validators.push(validatorId)
+        }
+        this._notifyError(e)
+      }
     },
 
     // ── Content Actions ───────────────────────────────────────────────────────


### PR DESCRIPTION
feat(adb): Validatoren definieren, speichern und an Aufgaben hängen


- Backend: ValidatorService, ValidatorController (CRUD unter /api/validators)
- Backend: Endpoints zum Verknuepfen/Lösen von Validatoren an Items
- Frontend: AdbValidatorEditor UI (verknuepfte/verfuegbare Chips, Erstellen-Dialog)
- Frontend: ApiAdapter, Store (allValidators, link/unlink-Actions)
- Fix: uploadBlob in ApiAdapter Interface, blobMimeType in Content, toItem mapped IDs