### PR TITLE
feat(adb): Autor/Lizenz/Typ auswählbar + Referenzdaten-Endpunkte

### DIFF
--- a/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
@@ -1,0 +1,79 @@
+package com.datenbank.backend.controller;
+
+import com.datenbank.backend.repository.AuthorRepository;
+import com.datenbank.backend.repository.ItemContentTypeRepository;
+import com.datenbank.backend.repository.ItemTypeRepository;
+import com.datenbank.backend.repository.LicenseRepository;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Read-only Endpunkte für die Referenzdaten (Lookup-Listen).
+ *
+ * Damit das Frontend Autor, Lizenz, Aufgaben-Typ und Content-Typ in
+ * Dropdowns anbieten kann, statt feste SEED-UUIDs hartzucodieren.
+ * Bewusst nur GET — diese Listen werden in dieser Iteration nicht über
+ * die UI gepflegt.
+ */
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ReferenceController {
+
+    private final AuthorRepository authorRepository;
+    private final LicenseRepository licenseRepository;
+    private final ItemTypeRepository itemTypeRepository;
+    private final ItemContentTypeRepository contentTypeRepository;
+
+    public ReferenceController(AuthorRepository authorRepository,
+                               LicenseRepository licenseRepository,
+                               ItemTypeRepository itemTypeRepository,
+                               ItemContentTypeRepository contentTypeRepository) {
+        this.authorRepository = authorRepository;
+        this.licenseRepository = licenseRepository;
+        this.itemTypeRepository = itemTypeRepository;
+        this.contentTypeRepository = contentTypeRepository;
+    }
+
+    // Schlanke DTOs (nur ID + Anzeigename) — ideal für Dropdowns.
+    public record AuthorDto(String id, String descriptor, String mail) {}
+    public record LicenseDto(String id, String name) {}
+    public record ItemTypeDto(String id, String name, String description) {}
+    public record ContentTypeDto(String id, String name, String description) {}
+
+    @GetMapping("/authors")
+    public List<AuthorDto> getAuthors() {
+        return authorRepository.findAll().stream()
+                .map(a -> new AuthorDto(a.getAuthorId().toString(), a.getDescriptor(), a.getMail()))
+                .toList();
+    }
+
+    @GetMapping("/licenses")
+    public List<LicenseDto> getLicenses() {
+        return licenseRepository.findAll().stream()
+                .map(l -> new LicenseDto(l.getLicenseId().toString(), l.getLicense()))
+                .toList();
+    }
+
+    @GetMapping("/item-types")
+    public List<ItemTypeDto> getItemTypes() {
+        return itemTypeRepository.findAll().stream()
+                .map(t -> new ItemTypeDto(
+                        t.getItemTypeId().toString(), t.getItemTypeName(), t.getDescription()))
+                .toList();
+    }
+
+    @GetMapping("/content-types")
+    public List<ContentTypeDto> getContentTypes() {
+        return contentTypeRepository.findAll().stream()
+                .map(c -> new ContentTypeDto(
+                        c.getItemContentTypeId().toString(),
+                        c.getItemContentTypeName(),
+                        c.getDescription()))
+                .toList();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
 
   db:
     image: postgres:16-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_DB: pwi_aufgabendatenbank
       POSTGRES_USER: postgres
@@ -20,6 +21,7 @@ services:
   backend:
     build:
       context: ./backend
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:
@@ -34,6 +36,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "8085:8085"
     environment:

--- a/frontend/src/feature/aufgabendatenbank/Adb.vue
+++ b/frontend/src/feature/aufgabendatenbank/Adb.vue
@@ -34,6 +34,7 @@ const store = useExerciseStore()
 const { sidebarWidth, containerRef, startResizing } = useSidebarResizer()
 
 onMounted(() => {
+  store.loadReferenceData()
   store.loadTree()
 })
 </script>

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -8,7 +8,11 @@ import type {
   CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload,
-  OrderTogglePayload
+  OrderTogglePayload,
+  AuthorDTO,
+  LicenseDTO,
+  ItemTypeDTO,
+  ContentTypeDTO
 } from './api-adapter.types'
 
 export class AdbApiService implements ApiAdapter {
@@ -33,6 +37,11 @@ export class AdbApiService implements ApiAdapter {
 
   async createItem(payload: CreateItemPayload): Promise<ItemDTO> {
     const { data } = await this.http.post<ItemDTO>('/items', payload)
+    return data
+  }
+
+  async updateItem(itemId: string, payload: CreateItemPayload): Promise<ItemDTO> {
+    const { data } = await this.http.put<ItemDTO>(`/items/${itemId}`, payload)
     return data
   }
 
@@ -94,6 +103,26 @@ export class AdbApiService implements ApiAdapter {
 
   async loadFullTree(): Promise<ItemDTO[]> {
     return this.getRootItems()
+  }
+
+  async getAuthors(): Promise<AuthorDTO[]> {
+    const { data } = await this.http.get<AuthorDTO[]>('/authors')
+    return data
+  }
+
+  async getLicenses(): Promise<LicenseDTO[]> {
+    const { data } = await this.http.get<LicenseDTO[]>('/licenses')
+    return data
+  }
+
+  async getItemTypes(): Promise<ItemTypeDTO[]> {
+    const { data } = await this.http.get<ItemTypeDTO[]>('/item-types')
+    return data
+  }
+
+  async getContentTypes(): Promise<ContentTypeDTO[]> {
+    const { data } = await this.http.get<ContentTypeDTO[]>('/content-types')
+    return data
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -51,6 +51,31 @@ export interface ContentSummaryDTO {
   hasBlobContent: boolean
 }
 
+// ── Referenzdaten (Lookup-Listen für Dropdowns) ──────────────────────────────
+
+export interface AuthorDTO {
+  id: string
+  descriptor: string
+  mail: string | null
+}
+
+export interface LicenseDTO {
+  id: string
+  name: string
+}
+
+export interface ItemTypeDTO {
+  id: string
+  name: string
+  description: string | null
+}
+
+export interface ContentTypeDTO {
+  id: string
+  name: string
+  description: string | null
+}
+
 export interface CreateItemPayload {
   authorId: string
   licenseId: string
@@ -92,6 +117,8 @@ export interface ApiAdapter {
 
   createItem(payload: CreateItemPayload): Promise<ItemDTO>
 
+  updateItem(itemId: string, payload: CreateItemPayload): Promise<ItemDTO>
+
   createCollection(payload: CreateCollectionPayload): Promise<ItemDTO>
 
   convertItemToCollection(itemId: string): Promise<ItemDTO>
@@ -117,4 +144,10 @@ export interface ApiAdapter {
   deleteContent(contentId: string): Promise<void>
 
   loadFullTree(): Promise<ItemDTO[]>
+
+  // Referenzdaten für Dropdowns
+  getAuthors(): Promise<AuthorDTO[]>
+  getLicenses(): Promise<LicenseDTO[]>
+  getItemTypes(): Promise<ItemTypeDTO[]>
+  getContentTypes(): Promise<ContentTypeDTO[]>
 }

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -9,7 +9,11 @@ import type {
   CreateContentPayload,
   CreateCollectionPayload,
   UpdateCollectionPayload,
-  OrderTogglePayload
+  OrderTogglePayload,
+  AuthorDTO,
+  LicenseDTO,
+  ItemTypeDTO,
+  ContentTypeDTO
 } from './api-adapter.types'
 import type { Item, Content, CollectionItem } from '@/lib/types'
 
@@ -137,6 +141,33 @@ export class DevAdbApiService implements ApiAdapter {
       contents: [],
       createdAt: nowISO(),
       updatedAt: nowISO()
+    }
+  }
+
+  async updateItem(itemId: string, payload: CreateItemPayload): Promise<ItemDTO> {
+    log('PUT', `/api/items/${itemId}`, payload)
+    const item = findItem(itemId, dummyData.rootItems)
+    const base = item ? toDTO(item) : null
+    return {
+      itemId,
+      authorId: payload.authorId,
+      authorDescriptor: base?.authorDescriptor ?? 'author',
+      licenseId: payload.licenseId,
+      licenseName: base?.licenseName ?? null,
+      itemTypeId: payload.itemTypeId,
+      itemTypeName: base?.itemTypeName ?? 'exercise',
+      itemTemplateId: payload.itemTemplateId ?? null,
+      rootItemId: payload.rootItemId ?? null,
+      tagIds: payload.tagIds ?? [],
+      validatorIds: payload.validatorIds ?? [],
+      modifierIds: payload.modifierIds ?? [],
+      isCollection: base?.isCollection ?? false,
+      collectionId: base?.collectionId ?? null,
+      contents: base?.contents ?? [],
+      createdAt: base?.createdAt ?? nowISO(),
+      updatedAt: nowISO(),
+      items: base?.items,
+      order: base?.order
     }
   }
 
@@ -327,6 +358,49 @@ export class DevAdbApiService implements ApiAdapter {
   async loadFullTree(): Promise<ItemDTO[]> {
     log('GET', '/api/items?root=true (loadFullTree)')
     return dummyData.rootItems.map(toDTO)
+  }
+
+  // ── Referenzdaten (gleiche Seeds wie database/init/init.sql) ───────────────
+
+  async getAuthors(): Promise<AuthorDTO[]> {
+    log('GET', '/api/authors')
+    return [
+      { id: 'd0000000-0000-0000-0000-000000000001', descriptor: 'Prof. Dr. Markus Siepermann', mail: 'markus.siepermann@mni.thm.de' },
+      { id: 'd0000000-0000-0000-0000-000000000002', descriptor: 'Johannes Kunz', mail: 'johannes.kunz@mni.thm.de' },
+      { id: 'd0000000-0000-0000-0000-000000000003', descriptor: 'Joelle Kamwa Mokam', mail: 'joelle.kamwa@mni.thm.de' }
+    ]
+  }
+
+  async getLicenses(): Promise<LicenseDTO[]> {
+    log('GET', '/api/licenses')
+    return [
+      { id: 'b0000000-0000-0000-0000-000000000001', name: 'CC-BY-4.0' },
+      { id: 'b0000000-0000-0000-0000-000000000002', name: 'CC-BY-SA-4.0' },
+      { id: 'b0000000-0000-0000-0000-000000000003', name: 'MIT' },
+      { id: 'b0000000-0000-0000-0000-000000000004', name: 'Internal-THM' }
+    ]
+  }
+
+  async getItemTypes(): Promise<ItemTypeDTO[]> {
+    log('GET', '/api/item-types')
+    return [
+      { id: 'e0000000-0000-0000-0000-000000000001', name: 'SQL-Abfrage', description: 'Aufgaben, die das Schreiben einer SQL-Abfrage erfordern' },
+      { id: 'e0000000-0000-0000-0000-000000000002', name: 'Modellierung', description: 'Erstellung eines Datenmodells' },
+      { id: 'e0000000-0000-0000-0000-000000000003', name: 'Multiple-Choice', description: 'Auswahl der richtigen Antwort(en) aus mehreren Optionen' },
+      { id: 'e0000000-0000-0000-0000-000000000004', name: 'Freitext', description: 'Offene Textantwort' }
+    ]
+  }
+
+  async getContentTypes(): Promise<ContentTypeDTO[]> {
+    log('GET', '/api/content-types')
+    return [
+      { id: 'a0000000-0000-0000-0000-000000000001', name: 'text/plain', description: 'Einfacher Text' },
+      { id: 'a0000000-0000-0000-0000-000000000002', name: 'text/markdown', description: 'Markdown-formatierter Text' },
+      { id: 'a0000000-0000-0000-0000-000000000003', name: 'application/json', description: 'Strukturierter JSON-Inhalt' },
+      { id: 'a0000000-0000-0000-0000-000000000004', name: 'image/png', description: 'PNG-Bilder' },
+      { id: 'a0000000-0000-0000-0000-000000000005', name: 'image/jpeg', description: 'JPEG-Bilder' },
+      { id: 'a0000000-0000-0000-0000-000000000006', name: 'application/pdf', description: 'PDF-Dokumente' }
+    ]
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -46,6 +46,48 @@
           />
         </div>
 
+        <div
+          v-if="inner"
+          class="meta-row"
+        >
+          <v-select
+            :model-value="inner.itemTypeId"
+            :items="store.itemTypes"
+            item-title="name"
+            item-value="id"
+            label="Typ"
+            density="compact"
+            variant="outlined"
+            hide-details
+            class="meta-select"
+            @update:model-value="(v) => onMeta({ itemTypeId: v })"
+          />
+          <v-select
+            :model-value="inner.authorId"
+            :items="store.authors"
+            item-title="descriptor"
+            item-value="id"
+            label="Autor"
+            density="compact"
+            variant="outlined"
+            hide-details
+            class="meta-select"
+            @update:model-value="(v) => onMeta({ authorId: v })"
+          />
+          <v-select
+            :model-value="inner.licenseId"
+            :items="store.licenses"
+            item-title="name"
+            item-value="id"
+            label="Lizenz"
+            density="compact"
+            variant="outlined"
+            hide-details
+            class="meta-select"
+            @update:model-value="(v) => onMeta({ licenseId: v })"
+          />
+        </div>
+
         <AdbContentList />
 
         <p class="text-caption text-grey">
@@ -67,6 +109,12 @@ import { useExerciseStore } from '@/stores/exerciseStore'
 
 const store = useExerciseStore()
 const showDeleteDialog = ref(false)
+
+const inner = computed(() => store.selectedInnerItem)
+
+function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: string }) {
+  if (inner.value) store.updateItemMeta(inner.value, meta)
+}
 
 const itemTypeLabel = computed(() => {
   if (!store.selectedInnerItem) return ''
@@ -123,6 +171,18 @@ function deleteSelectedItem() {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 12px;
+}
+
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.meta-select {
+  flex: 1 1 160px;
+  min-width: 140px;
 }
 
 .order-toggle-area {

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
@@ -69,6 +69,33 @@
           @keydown.escape="editingText = false"
         />
       </div>
+
+      <div class="content-meta-row">
+        <v-select
+          :model-value="content.contentTypeId"
+          :items="store.contentTypes"
+          item-title="name"
+          item-value="id"
+          label="Inhaltstyp"
+          density="compact"
+          variant="outlined"
+          hide-details
+          class="content-meta-select"
+          @update:model-value="(v) => emit('update:meta', { contentTypeId: v })"
+        />
+        <v-select
+          :model-value="content.licenseId"
+          :items="store.licenses"
+          item-title="name"
+          item-value="id"
+          label="Lizenz"
+          density="compact"
+          variant="outlined"
+          hide-details
+          class="content-meta-select"
+          @update:model-value="(v) => emit('update:meta', { licenseId: v })"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -76,6 +103,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import type { Content } from '@/lib/types'
+import { useExerciseStore } from '@/stores/exerciseStore'
 
 const props = defineProps<{
   content: Content
@@ -84,8 +112,11 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:text': [value: string]
   'update:purpose': [value: string]
+  'update:meta': [meta: { contentTypeId?: string; licenseId?: string }]
   delete: []
 }>()
+
+const store = useExerciseStore()
 
 const editingText = ref(false)
 const editingPurpose = ref(false)
@@ -239,6 +270,18 @@ function startEditText() {
 
 .card-body {
   padding-left: 0;
+}
+
+.content-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.content-meta-select {
+  flex: 1 1 140px;
+  min-width: 120px;
 }
 
 .content-text {

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
@@ -6,6 +6,7 @@
       :content="content"
       @update:text="(val) => store.updateContentText(index, val)"
       @update:purpose="(val) => store.updateContentPurpose(index, val)"
+      @update:meta="(m) => store.updateContentMeta(index, m)"
       @delete="store.removeContentFromSelectedItem(index)"
     />
 

--- a/frontend/src/feature/aufgabendatenbank/validation.ts
+++ b/frontend/src/feature/aufgabendatenbank/validation.ts
@@ -96,7 +96,6 @@ export function validateTreeData(rootItems: Item[]): ValidationIssue[] {
 
   return [
     ...checkOnlyCollectionsHaveChildren(allItems),
-    ...checkNoDuplicateItems(rootItems),
     ...checkNoDanglingRootItemId(allItems)
   ]
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -12,6 +12,12 @@ export interface Content {
   purpose: string
   jsonContent: Record<string, any>
   blobContent: string
+
+  // Backend-IDs (für Dropdown-Auswahl). Optional, da viele Stellen
+  // Content-Objekte als Literal bauen.
+  authorId?: string | null
+  licenseId?: string | null
+  contentTypeId?: string | null
 }
 
 export interface Item {
@@ -30,6 +36,12 @@ export interface Item {
   // Backend item_collection_id (nur bei Kollektionen gesetzt). Wird für
   // alle /api/collections/{id}/... Aufrufe verwendet — NICHT die item_id (id).
   collectionId?: string | null
+  // Backend-IDs für Dropdown-Auswahl (Autor/Lizenz/Typ). Optional, da
+  // viele Stellen Item-Objekte als Literal bauen.
+  authorId?: string | null
+  licenseId?: string | null
+  itemTypeId?: string | null
+  itemTypeName?: string | null
 }
 
 export type Collection = Item & {

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -16,7 +16,11 @@ import type {
   ItemDTO,
   ContentDTO,
   ContentSummaryDTO,
-  CollectionItemDTO
+  CollectionItemDTO,
+  AuthorDTO,
+  LicenseDTO,
+  ItemTypeDTO,
+  ContentTypeDTO
 } from '@/feature/aufgabendatenbank/api-adapter.types'
 
 // ── Seed-UUIDs (müssen mit database/init/init.sql übereinstimmen) ─────────────
@@ -70,7 +74,10 @@ function toFullContent(dto: ContentDTO): Content {
     tags: dto.tagIds,
     purpose: dto.purpose ?? '',
     jsonContent,
-    blobContent: dto.hasBlobContent ? '(binary)' : ''
+    blobContent: dto.hasBlobContent ? '(binary)' : '',
+    authorId: dto.authorId ?? null,
+    licenseId: dto.licenseId ?? null,
+    contentTypeId: dto.itemContentTypeId ?? null
   }
 }
 
@@ -91,7 +98,11 @@ function toItem(dto: ItemDTO): Item {
     // crasht z. B. die Validierung mit undefined.flatMap(...).
     items: dto.items?.map(toCollectionItem) ?? (dto.isCollection ? [] : undefined),
     order: dto.order,
-    collectionId: dto.collectionId ?? null
+    collectionId: dto.collectionId ?? null,
+    authorId: dto.authorId ?? null,
+    licenseId: dto.licenseId ?? null,
+    itemTypeId: dto.itemTypeId ?? null,
+    itemTypeName: dto.itemTypeName ?? null
   }
 }
 
@@ -113,6 +124,11 @@ interface ExerciseState {
   loadingContent: boolean
   error: string | null
   loadingChildrenIds: string[]
+  // Referenzdaten für Dropdowns (Autor/Lizenz/Typ/Content-Typ)
+  authors: AuthorDTO[]
+  licenses: LicenseDTO[]
+  itemTypes: ItemTypeDTO[]
+  contentTypes: ContentTypeDTO[]
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -124,7 +140,11 @@ export const useExerciseStore = defineStore('exercise', {
     loading: false,
     loadingContent: false,
     error: null,
-    loadingChildrenIds: []
+    loadingChildrenIds: [],
+    authors: [],
+    licenses: [],
+    itemTypes: [],
+    contentTypes: []
   }),
 
   getters: {
@@ -132,6 +152,13 @@ export const useExerciseStore = defineStore('exercise', {
       if (!state.selectedItem) return null
       return getInnerItem(state.selectedItem)
     },
+
+    // Default-IDs für die Erstellung: erster Eintrag der jeweiligen
+    // Referenzliste, Fallback auf die festen Seed-UUIDs (falls Liste leer).
+    defaultAuthorId: (state): string => state.authors[0]?.id ?? SEED_AUTHOR_ID,
+    defaultLicenseId: (state): string => state.licenses[0]?.id ?? SEED_LICENSE_ID,
+    defaultItemTypeId: (state): string => state.itemTypes[0]?.id ?? SEED_ITEM_TYPE_ID,
+    defaultContentTypeId: (state): string => state.contentTypes[0]?.id ?? SEED_CONTENT_TYPE_ID,
 
     isCollectionSelected(): boolean {
       const inner = this.selectedInnerItem
@@ -158,6 +185,30 @@ export const useExerciseStore = defineStore('exercise', {
       const msg = (e as any)?.response?.data?.message || (e as any)?.response?.data || String(e)
       const status = (e as any)?.response?.status ? `[${(e as any).response.status}] ` : ''
       notifStore.push(status + JSON.stringify(msg), 'error', 12000)
+    },
+
+    // ── Referenzdaten ─────────────────────────────────────────────────────────
+
+    /**
+     * Load reference lists (authors, licenses, item types, content types)
+     * used to populate the editor dropdowns. Called once on mount.
+     */
+    async loadReferenceData() {
+      if (!_adapter) return
+      try {
+        const [authors, licenses, itemTypes, contentTypes] = await Promise.all([
+          _adapter.getAuthors(),
+          _adapter.getLicenses(),
+          _adapter.getItemTypes(),
+          _adapter.getContentTypes()
+        ])
+        this.authors = authors
+        this.licenses = licenses
+        this.itemTypes = itemTypes
+        this.contentTypes = contentTypes
+      } catch (e) {
+        this._notifyError(e)
+      }
     },
 
     // ── Initialisation (progressive loading) ──────────────────────────────────
@@ -289,21 +340,27 @@ export const useExerciseStore = defineStore('exercise', {
       const inner = this.selectedInnerItem
       if (!inner) return
       const now = Date.now().toString()
+      const licenseId = inner.licenseId ?? this.defaultLicenseId
+      const authorId = inner.authorId ?? this.defaultAuthorId
+      const contentTypeId = this.defaultContentTypeId
       const content: Content = {
         id: 'content-' + now,
-        license: null,
-        contentType: 'text',
+        license: inner.license ?? null,
+        contentType: this.contentTypes.find((c) => c.id === contentTypeId)?.name ?? 'text',
         author: inner.author ?? 'author',
         tags: [],
         purpose: 'Neuer Inhalt',
         jsonContent: { text: '' },
-        blobContent: ''
+        blobContent: '',
+        authorId,
+        licenseId,
+        contentTypeId
       }
       inner.contents.push(content)
       _adapter?.createContent(inner.id, {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId,
+        itemContentTypeId: contentTypeId,
+        authorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).then((dto) => {
@@ -327,9 +384,9 @@ export const useExerciseStore = defineStore('exercise', {
       const content = inner.contents[index]
       content.jsonContent.text = text
       _adapter?.updateContent(content.id ?? '', {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId: content.licenseId ?? this.defaultLicenseId,
+        itemContentTypeId: content.contentTypeId ?? this.defaultContentTypeId,
+        authorId: content.authorId ?? this.defaultAuthorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).catch((e) => this._notifyError(e))
@@ -341,9 +398,35 @@ export const useExerciseStore = defineStore('exercise', {
       const content = inner.contents[index]
       content.purpose = purpose
       _adapter?.updateContent(content.id ?? '', {
-        licenseId: SEED_LICENSE_ID,
-        itemContentTypeId: SEED_CONTENT_TYPE_ID,
-        authorId: SEED_AUTHOR_ID,
+        licenseId: content.licenseId ?? this.defaultLicenseId,
+        itemContentTypeId: content.contentTypeId ?? this.defaultContentTypeId,
+        authorId: content.authorId ?? this.defaultAuthorId,
+        purpose: content.purpose,
+        jsonSerializedContent: JSON.stringify(content.jsonContent)
+      }).catch((e) => this._notifyError(e))
+    },
+
+    /**
+     * Update a content block's type / license from the editor dropdowns.
+     * Updates local labels and persists via PUT /contents/{id}.
+     */
+    updateContentMeta(index: number, meta: { contentTypeId?: string; licenseId?: string }) {
+      const inner = this.selectedInnerItem
+      if (!inner || !inner.contents[index]) return
+      const content = inner.contents[index]
+      if (meta.contentTypeId !== undefined) {
+        content.contentTypeId = meta.contentTypeId
+        content.contentType =
+          this.contentTypes.find((c) => c.id === meta.contentTypeId)?.name ?? content.contentType
+      }
+      if (meta.licenseId !== undefined) {
+        content.licenseId = meta.licenseId
+        content.license = this.licenses.find((l) => l.id === meta.licenseId)?.name ?? content.license
+      }
+      _adapter?.updateContent(content.id ?? '', {
+        licenseId: content.licenseId ?? this.defaultLicenseId,
+        itemContentTypeId: content.contentTypeId ?? this.defaultContentTypeId,
+        authorId: content.authorId ?? this.defaultAuthorId,
         purpose: content.purpose,
         jsonSerializedContent: JSON.stringify(content.jsonContent)
       }).catch((e) => this._notifyError(e))
@@ -390,26 +473,41 @@ export const useExerciseStore = defineStore('exercise', {
     /** Build a minimal Item object with a unique ID and single Content block. */
     _createItemData(rootItemId: string | null = null): Item {
       const now = Date.now().toString()
+      const authorId = this.defaultAuthorId
+      const licenseId = this.defaultLicenseId
+      const itemTypeId = this.defaultItemTypeId
+      const contentTypeId = this.defaultContentTypeId
+      const authorName = this.authors.find((a) => a.id === authorId)?.descriptor ?? 'author'
+      const licenseName = this.licenses.find((l) => l.id === licenseId)?.name ?? null
+      const typeName = this.itemTypes.find((t) => t.id === itemTypeId)?.name ?? null
+      const contentTypeName = this.contentTypes.find((c) => c.id === contentTypeId)?.name ?? 'text'
       return {
         id: 'item-' + now,
         item_type: 'exercise',
-        author: 'author',
+        author: authorName,
         representationTemplate: null,
-        license: null,
+        license: licenseName,
         tags: [],
         validators: [],
         modifiers: [],
         rootItemId,
+        authorId,
+        licenseId,
+        itemTypeId,
+        itemTypeName: typeName,
         contents: [
           {
             id: 'content-' + now,
-            license: null,
-            contentType: 'text',
-            author: 'author',
+            license: licenseName,
+            contentType: contentTypeName,
+            author: authorName,
             tags: [],
             purpose: 'Neuer Inhalt',
             jsonContent: { text: '' },
-            blobContent: ''
+            blobContent: '',
+            authorId,
+            licenseId,
+            contentTypeId
           }
         ]
       }
@@ -445,25 +543,52 @@ export const useExerciseStore = defineStore('exercise', {
 
     // ── CRUD Actions ──
 
+    /**
+     * Update an item's metadata (author / license / item-type) from the
+     * editor dropdowns. Updates the local item (incl. display labels) and
+     * persists via PUT /items/{id}.
+     */
+    updateItemMeta(item: Item, meta: { authorId?: string; licenseId?: string; itemTypeId?: string }) {
+      if (meta.authorId !== undefined) item.authorId = meta.authorId
+      if (meta.licenseId !== undefined) item.licenseId = meta.licenseId
+      if (meta.itemTypeId !== undefined) item.itemTypeId = meta.itemTypeId
+
+      // Anzeige-Labels mitziehen, damit die UI ohne Reload stimmt
+      const author = this.authors.find((a) => a.id === item.authorId)
+      if (author) item.author = author.descriptor
+      const license = this.licenses.find((l) => l.id === item.licenseId)
+      item.license = license ? license.name : item.license
+      const type = this.itemTypes.find((t) => t.id === item.itemTypeId)
+      if (type) item.itemTypeName = type.name
+
+      _adapter?.updateItem(item.id, {
+        authorId: item.authorId ?? this.defaultAuthorId,
+        licenseId: item.licenseId ?? this.defaultLicenseId,
+        itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
+        rootItemId: item.rootItemId ?? null
+      }).catch((e) => this._notifyError(e))
+    },
+
     createItem(rootItemId: string | null = null, addToRoot = true, onCreated?: (realId: string) => void): Item {
       const item = this._createItemData(rootItemId)
       if (addToRoot) this.rootItems.push(item)
       _adapter?.createItem({
-        authorId: SEED_AUTHOR_ID,
-        licenseId: SEED_LICENSE_ID,
-        itemTypeId: SEED_ITEM_TYPE_ID,
+        authorId: item.authorId ?? this.defaultAuthorId,
+        licenseId: item.licenseId ?? this.defaultLicenseId,
+        itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
         rootItemId: item.rootItemId ?? null
       }).then((dto) => {
         if (dto) {
           item.id = dto.itemId
           onCreated?.(dto.itemId)
           if (item.contents.length > 0) {
+            const c0 = item.contents[0]
             _adapter?.createContent(dto.itemId, {
-              licenseId: SEED_LICENSE_ID,
-              itemContentTypeId: SEED_CONTENT_TYPE_ID,
-              authorId: SEED_AUTHOR_ID,
-              purpose: item.contents[0].purpose,
-              jsonSerializedContent: JSON.stringify(item.contents[0].jsonContent)
+              licenseId: c0.licenseId ?? this.defaultLicenseId,
+              itemContentTypeId: c0.contentTypeId ?? this.defaultContentTypeId,
+              authorId: c0.authorId ?? this.defaultAuthorId,
+              purpose: c0.purpose,
+              jsonSerializedContent: JSON.stringify(c0.jsonContent)
             }).then((contentDto) => {
               if (contentDto && item.contents[0]) {
                 item.contents[0].id = contentDto.itemContentId
@@ -478,15 +603,22 @@ export const useExerciseStore = defineStore('exercise', {
 
     createCollection(): Collection {
       const now = Date.now().toString()
+      const authorId = this.defaultAuthorId
+      const licenseId = this.defaultLicenseId
+      const itemTypeId = this.defaultItemTypeId
       const collection: Collection = {
         id: 'coll-' + now,
         item_type: 'collection',
-        author: 'author',
+        author: this.authors.find((a) => a.id === authorId)?.descriptor ?? 'author',
         representationTemplate: null,
-        license: null,
+        license: this.licenses.find((l) => l.id === licenseId)?.name ?? null,
         tags: [],
         validators: [],
         modifiers: [],
+        authorId,
+        licenseId,
+        itemTypeId,
+        itemTypeName: this.itemTypes.find((t) => t.id === itemTypeId)?.name ?? null,
         // Eine Kollektion ist im Backend eine Item ohne eigenen Content.
         contents: [],
         items: [],
@@ -497,9 +629,9 @@ export const useExerciseStore = defineStore('exercise', {
       // (POST /items → POST /items/{id}/collection). So taucht die Kollektion
       // beim Neuladen über GET /items?root=true wieder auf.
       _adapter?.createItem({
-        authorId: SEED_AUTHOR_ID,
-        licenseId: SEED_LICENSE_ID,
-        itemTypeId: SEED_ITEM_TYPE_ID,
+        authorId,
+        licenseId,
+        itemTypeId,
         rootItemId: null
       })
         .then((dto) => {


### PR DESCRIPTION
Macht Autor, Lizenz und Typ im Editor auswählbar (statt fester SEED-IDs), inkl. read-only Endpunkten für die Referenzdaten.

- Backend: ReferenceController (GET /api/authors, /licenses, /item-types, /content-types)
- Adapter/Store: Referenzlisten laden, updateItem, Default-Werte; SEED-IDs ersetzt
- Editor: Dropdowns für Typ/Autor/Lizenz, sowie Inhaltstyp/Lizenz je Content-Block
- Nebenbei: doppelte rootItems/Collection-Validierung entfernt (Notification-Spam), restart: unless-stopped für die Container

Getestet: type-check + Tests grün, manuell gegen die echte DB.