### PR TITLE
feat(adb): Referenzdaten anlegen – „+ Neu" für Autor/Lizenz/Typ (#70)

### DIFF
--- a/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
@@ -1,12 +1,20 @@
 package com.datenbank.backend.controller;
 
+import com.datenbank.backend.entity.Author;
+import com.datenbank.backend.entity.ItemContentType;
+import com.datenbank.backend.entity.ItemType;
+import com.datenbank.backend.entity.License;
 import com.datenbank.backend.repository.AuthorRepository;
 import com.datenbank.backend.repository.ItemContentTypeRepository;
 import com.datenbank.backend.repository.ItemTypeRepository;
 import com.datenbank.backend.repository.LicenseRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -45,6 +53,12 @@ public class ReferenceController {
     public record ItemTypeDto(String id, String name, String description) {}
     public record ContentTypeDto(String id, String name, String description) {}
 
+    // Request-Bodies zum Anlegen neuer Referenzdaten.
+    public record AuthorCreate(String descriptor, String mail) {}
+    public record LicenseCreate(String name) {}
+    public record ItemTypeCreate(String name, String description) {}
+    public record ContentTypeCreate(String name, String description) {}
+
     @GetMapping("/authors")
     public List<AuthorDto> getAuthors() {
         return authorRepository.findAll().stream()
@@ -75,5 +89,37 @@ public class ReferenceController {
                         c.getItemContentTypeName(),
                         c.getDescription()))
                 .toList();
+    }
+
+    // ── Anlegen neuer Referenzdaten ──────────────────────────────────────────
+
+    @PostMapping("/authors")
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthorDto createAuthor(@RequestBody AuthorCreate body) {
+        Author a = authorRepository.save(new Author(body.descriptor(), body.mail()));
+        return new AuthorDto(a.getAuthorId().toString(), a.getDescriptor(), a.getMail());
+    }
+
+    @PostMapping("/licenses")
+    @ResponseStatus(HttpStatus.CREATED)
+    public LicenseDto createLicense(@RequestBody LicenseCreate body) {
+        License l = licenseRepository.save(new License(body.name()));
+        return new LicenseDto(l.getLicenseId().toString(), l.getLicense());
+    }
+
+    @PostMapping("/item-types")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ItemTypeDto createItemType(@RequestBody ItemTypeCreate body) {
+        ItemType t = itemTypeRepository.save(new ItemType(body.name(), body.description()));
+        return new ItemTypeDto(t.getItemTypeId().toString(), t.getItemTypeName(), t.getDescription());
+    }
+
+    @PostMapping("/content-types")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ContentTypeDto createContentType(@RequestBody ContentTypeCreate body) {
+        ItemContentType c = contentTypeRepository.save(
+                new ItemContentType(body.name(), body.description()));
+        return new ContentTypeDto(
+                c.getItemContentTypeId().toString(), c.getItemContentTypeName(), c.getDescription());
     }
 }

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -124,6 +124,26 @@ export class AdbApiService implements ApiAdapter {
     const { data } = await this.http.get<ContentTypeDTO[]>('/content-types')
     return data
   }
+
+  async createAuthor(payload: { descriptor: string; mail: string | null }): Promise<AuthorDTO> {
+    const { data } = await this.http.post<AuthorDTO>('/authors', payload)
+    return data
+  }
+
+  async createLicense(payload: { name: string }): Promise<LicenseDTO> {
+    const { data } = await this.http.post<LicenseDTO>('/licenses', payload)
+    return data
+  }
+
+  async createItemType(payload: { name: string; description: string | null }): Promise<ItemTypeDTO> {
+    const { data } = await this.http.post<ItemTypeDTO>('/item-types', payload)
+    return data
+  }
+
+  async createContentType(payload: { name: string; description: string | null }): Promise<ContentTypeDTO> {
+    const { data } = await this.http.post<ContentTypeDTO>('/content-types', payload)
+    return data
+  }
 }
 
 export default new AdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -150,4 +150,10 @@ export interface ApiAdapter {
   getLicenses(): Promise<LicenseDTO[]>
   getItemTypes(): Promise<ItemTypeDTO[]>
   getContentTypes(): Promise<ContentTypeDTO[]>
+
+  // Neue Referenzdaten anlegen
+  createAuthor(payload: { descriptor: string; mail: string | null }): Promise<AuthorDTO>
+  createLicense(payload: { name: string }): Promise<LicenseDTO>
+  createItemType(payload: { name: string; description: string | null }): Promise<ItemTypeDTO>
+  createContentType(payload: { name: string; description: string | null }): Promise<ContentTypeDTO>
 }

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -402,6 +402,26 @@ export class DevAdbApiService implements ApiAdapter {
       { id: 'a0000000-0000-0000-0000-000000000006', name: 'application/pdf', description: 'PDF-Dokumente' }
     ]
   }
+
+  async createAuthor(payload: { descriptor: string; mail: string | null }): Promise<AuthorDTO> {
+    log('POST', '/api/authors', payload)
+    return { id: crypto.randomUUID(), descriptor: payload.descriptor, mail: payload.mail }
+  }
+
+  async createLicense(payload: { name: string }): Promise<LicenseDTO> {
+    log('POST', '/api/licenses', payload)
+    return { id: crypto.randomUUID(), name: payload.name }
+  }
+
+  async createItemType(payload: { name: string; description: string | null }): Promise<ItemTypeDTO> {
+    log('POST', '/api/item-types', payload)
+    return { id: crypto.randomUUID(), name: payload.name, description: payload.description }
+  }
+
+  async createContentType(payload: { name: string; description: string | null }): Promise<ContentTypeDTO> {
+    log('POST', '/api/content-types', payload)
+    return { id: crypto.randomUUID(), name: payload.name, description: payload.description }
+  }
 }
 
 export default new DevAdbApiService()

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -50,39 +50,30 @@
           v-if="inner"
           class="meta-row"
         >
-          <v-select
+          <AdbRefSelect
             :model-value="inner.itemTypeId"
             :items="store.itemTypes"
             item-title="name"
-            item-value="id"
             label="Typ"
-            density="compact"
-            variant="outlined"
-            hide-details
+            type="itemType"
             class="meta-select"
             @update:model-value="(v) => onMeta({ itemTypeId: v })"
           />
-          <v-select
+          <AdbRefSelect
             :model-value="inner.authorId"
             :items="store.authors"
             item-title="descriptor"
-            item-value="id"
             label="Autor"
-            density="compact"
-            variant="outlined"
-            hide-details
+            type="author"
             class="meta-select"
             @update:model-value="(v) => onMeta({ authorId: v })"
           />
-          <v-select
+          <AdbRefSelect
             :model-value="inner.licenseId"
             :items="store.licenses"
             item-title="name"
-            item-value="id"
             label="Lizenz"
-            density="compact"
-            variant="outlined"
-            hide-details
+            type="license"
             class="meta-select"
             @update:model-value="(v) => onMeta({ licenseId: v })"
           />
@@ -105,6 +96,7 @@
 import { computed, ref } from 'vue'
 import AdbContentList from './components/AdbContentList.vue'
 import AdbDeleteDialog from './components/AdbDeleteDialog.vue'
+import AdbRefSelect from '../toolbar/AdbRefSelect.vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
 
 const store = useExerciseStore()
@@ -181,8 +173,8 @@ function deleteSelectedItem() {
 }
 
 .meta-select {
-  flex: 1 1 160px;
-  min-width: 140px;
+  flex: 1 1 240px;
+  min-width: 220px;
 }
 
 .order-toggle-area {

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
@@ -71,27 +71,21 @@
       </div>
 
       <div class="content-meta-row">
-        <v-select
+        <AdbRefSelect
           :model-value="content.contentTypeId"
           :items="store.contentTypes"
           item-title="name"
-          item-value="id"
           label="Inhaltstyp"
-          density="compact"
-          variant="outlined"
-          hide-details
+          type="contentType"
           class="content-meta-select"
           @update:model-value="(v) => emit('update:meta', { contentTypeId: v })"
         />
-        <v-select
+        <AdbRefSelect
           :model-value="content.licenseId"
           :items="store.licenses"
           item-title="name"
-          item-value="id"
           label="Lizenz"
-          density="compact"
-          variant="outlined"
-          hide-details
+          type="license"
           class="content-meta-select"
           @update:model-value="(v) => emit('update:meta', { licenseId: v })"
         />
@@ -104,6 +98,7 @@
 import { ref, computed, nextTick } from 'vue'
 import type { Content } from '@/lib/types'
 import { useExerciseStore } from '@/stores/exerciseStore'
+import AdbRefSelect from '../../toolbar/AdbRefSelect.vue'
 
 const props = defineProps<{
   content: Content
@@ -280,8 +275,8 @@ function startEditText() {
 }
 
 .content-meta-select {
-  flex: 1 1 140px;
-  min-width: 120px;
+  flex: 1 1 240px;
+  min-width: 220px;
 }
 
 .content-text {

--- a/frontend/src/feature/aufgabendatenbank/toolbar/AdbCreateDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/toolbar/AdbCreateDialog.vue
@@ -9,37 +9,28 @@
         {{ store.createDialogTarget ? 'Neue Aufgabe in Sammlung' : 'Neue Aufgabe' }}
       </v-card-title>
       <v-card-text>
-        <v-select
+        <AdbRefSelect
           v-model="itemTypeId"
           :items="store.itemTypes"
           item-title="name"
-          item-value="id"
           label="Typ"
-          variant="outlined"
-          density="compact"
-          hide-details
+          type="itemType"
           class="mb-3"
         />
-        <v-select
+        <AdbRefSelect
           v-model="authorId"
           :items="store.authors"
           item-title="descriptor"
-          item-value="id"
           label="Autor"
-          variant="outlined"
-          density="compact"
-          hide-details
+          type="author"
           class="mb-3"
         />
-        <v-select
+        <AdbRefSelect
           v-model="licenseId"
           :items="store.licenses"
           item-title="name"
-          item-value="id"
           label="Lizenz"
-          variant="outlined"
-          density="compact"
-          hide-details
+          type="license"
           class="mb-3"
         />
         <v-textarea
@@ -75,6 +66,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import { useExerciseStore } from '@/stores/exerciseStore'
+import AdbRefSelect from './AdbRefSelect.vue'
 
 const store = useExerciseStore()
 

--- a/frontend/src/feature/aufgabendatenbank/toolbar/AdbRefSelect.vue
+++ b/frontend/src/feature/aufgabendatenbank/toolbar/AdbRefSelect.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="ref-row">
+    <v-select
+      :model-value="modelValue"
+      :items="items"
+      :item-title="itemTitle"
+      item-value="id"
+      :label="label"
+      variant="outlined"
+      density="compact"
+      hide-details
+      class="ref-select"
+      @update:model-value="onSelect"
+    />
+    <v-btn
+      variant="tonal"
+      color="primary"
+      prepend-icon="mdi-plus"
+      class="ref-new-btn"
+      @click="dialog = true"
+    >
+      Neu
+    </v-btn>
+
+    <v-dialog
+      v-model="dialog"
+      max-width="420"
+    >
+      <v-card class="ref-card">
+        <v-card-title class="ref-title">
+          {{ titleText }}
+        </v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="primary"
+            label="Name"
+            variant="outlined"
+            density="compact"
+            hide-details
+            autofocus
+            class="mb-3"
+            @keyup.enter="confirm"
+          />
+          <v-text-field
+            v-if="secondaryLabel"
+            v-model="secondary"
+            :label="secondaryLabel"
+            variant="outlined"
+            density="compact"
+            hide-details
+            @keyup.enter="confirm"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            variant="text"
+            class="cancel-btn"
+            @click="close"
+          >
+            Abbrechen
+          </v-btn>
+          <v-btn
+            variant="text"
+            class="confirm-btn"
+            :disabled="!primary.trim()"
+            @click="confirm"
+          >
+            Erstellen
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useExerciseStore } from '@/stores/exerciseStore'
+
+type RefType = 'author' | 'license' | 'itemType' | 'contentType'
+
+const props = defineProps<{
+  modelValue: string | null | undefined
+  label: string
+  items: unknown[]
+  itemTitle: string
+  type: RefType
+}>()
+const emit = defineEmits<{ 'update:modelValue': [value: string | undefined] }>()
+
+const store = useExerciseStore()
+const dialog = ref(false)
+const primary = ref('')
+const secondary = ref('')
+
+// v-select kann null liefern (z. B. beim Leeren) -> auf undefined normalisieren.
+function onSelect(v: unknown) {
+  emit('update:modelValue', (v as string | null) ?? undefined)
+}
+
+const titleText = computed(
+  () =>
+    ({
+      author: 'Neuer Autor',
+      license: 'Neue Lizenz',
+      itemType: 'Neuer Typ',
+      contentType: 'Neuer Inhaltstyp'
+    })[props.type]
+)
+
+// Lizenz hat kein zweites Feld (Schema: nur der Name).
+const secondaryLabel = computed(() => {
+  if (props.type === 'author') return 'Mail'
+  if (props.type === 'license') return ''
+  return 'Beschreibung'
+})
+
+function close() {
+  dialog.value = false
+  primary.value = ''
+  secondary.value = ''
+}
+
+async function confirm() {
+  if (!primary.value.trim()) return
+  const created = await store.createReference(props.type, primary.value, secondary.value)
+  // Bei Erfolg auswählen und schliessen; sonst offen lassen (Fehler kommt als Notification)
+  if (created) {
+    emit('update:modelValue', created.id)
+    close()
+  }
+}
+</script>
+
+<style scoped>
+.ref-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ref-select {
+  flex: 1 1 auto;
+}
+
+.ref-new-btn {
+  flex: 0 0 auto;
+}
+
+.ref-card {
+  background-color: #1e1e1e !important;
+  color: #cccccc !important;
+}
+
+.ref-title {
+  color: #cccccc;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.cancel-btn {
+  color: #969696 !important;
+}
+
+.confirm-btn {
+  color: #007fd4 !important;
+}
+</style>

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -216,6 +216,61 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
+    /**
+     * Neue Referenzdaten anlegen (Autor/Lizenz/Typ/Inhaltstyp). Legt sie per
+     * POST an, hängt sie an die passende Liste und gibt den neuen Datensatz
+     * zurück, damit die UI ihn direkt auswählen kann.
+     * `primary` = Name/Descriptor, `secondary` = Mail (Autor) bzw. Beschreibung.
+     */
+    async createReference(
+      type: 'author' | 'license' | 'itemType' | 'contentType',
+      primary: string,
+      secondary = ''
+    ): Promise<{ id: string } | null> {
+      if (!_adapter || !primary.trim()) return null
+      const name = primary.trim()
+      const extra = secondary.trim() || null
+
+      // Kein Duplikat (Name-Vergleich ohne Gross-/Kleinschreibung)
+      const lower = name.toLowerCase()
+      const exists =
+        type === 'author'
+          ? this.authors.some((a) => a.descriptor.toLowerCase() === lower)
+          : type === 'license'
+            ? this.licenses.some((l) => l.name.toLowerCase() === lower)
+            : type === 'itemType'
+              ? this.itemTypes.some((t) => t.name.toLowerCase() === lower)
+              : this.contentTypes.some((c) => c.name.toLowerCase() === lower)
+      if (exists) {
+        useNotificationStore().push(`„${name}" existiert bereits.`, 'error', 6000)
+        return null
+      }
+
+      try {
+        if (type === 'author') {
+          const dto = await _adapter.createAuthor({ descriptor: name, mail: extra })
+          this.authors.push(dto)
+          return dto
+        }
+        if (type === 'license') {
+          const dto = await _adapter.createLicense({ name })
+          this.licenses.push(dto)
+          return dto
+        }
+        if (type === 'itemType') {
+          const dto = await _adapter.createItemType({ name, description: extra })
+          this.itemTypes.push(dto)
+          return dto
+        }
+        const dto = await _adapter.createContentType({ name, description: extra })
+        this.contentTypes.push(dto)
+        return dto
+      } catch (e) {
+        this._notifyError(e)
+        return null
+      }
+    },
+
     // ── Initialisation (progressive loading) ──────────────────────────────────
 
     /**


### PR DESCRIPTION
Macht Referenzdaten anlegbar: neben jedem Dropdown (Autor/Lizenz/Typ/Inhaltstyp) gibt es jetzt einen „+ Neu"-Button. Klick öffnet einen kleinen Dialog, der neue Eintrag wird per POST angelegt, der Liste hinzugefügt und direkt ausgewählt.

- Backend: neue POST-Endpunkte in ReferenceController (legt nur neue Zeilen an, kein Schema-Eingriff).
- Wiederverwendbares AdbRefSelect (Dropdown + „+ Neu") im Erstellen-Formular, im Editor und in den Inhaltsblöcken.
- Felder je Typ: Autor = Name + Mail, Lizenz = nur Name, Typ/Inhaltstyp = Name + Beschreibung.
- Duplikat-Prüfung beim Namen (Groß-/Kleinschreibung egal) statt stiller Dopplung.

Baut auf #76 (Aufgabe-Formular) auf — Base ist dessen Branch, GitHub stellt nach dem Merge automatisch auf main um.

