### PR TITLE
fix(adb): kaputten #74-Merge auf main reparieren

### DIFF
--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -112,14 +112,6 @@ export class AdbApiService implements ApiAdapter {
     return data
   }
 
-  async uploadBlob(contentId: string, file: File): Promise<void> {
-    const formData = new FormData()
-    formData.append('file', file)
-    await this.http.post(`/contents/${contentId}/blob`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' }
-    })
-  }
-
   // ── Validators ───────────────────────────────────────────────────────
 
   async getValidators(): Promise<ValidatorDTO[]> {

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -135,8 +135,6 @@ export interface ApiAdapter {
 
   getItemsByRootId(rootItemId: string): Promise<ItemDTO[]>
 
-  uploadBlob(contentId: string, file: File): Promise<void>
-
   // ── Validators ───────────────────────────────────────────────────────
 
   getValidators(): Promise<ValidatorDTO[]>

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -369,10 +369,6 @@ export class DevAdbApiService implements ApiAdapter {
       .map(ci => toDTO(ci.item))
   }
 
-  async uploadBlob(contentId: string, file: File): Promise<void> {
-    log('POST', `/api/contents/${contentId}/blob`, { fileName: file.name, size: file.size })
-  }
-
   // ── Validators ───────────────────────────────────────────────────────
 
   private _validators: ValidatorDTO[] = [...seedValidators]

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -134,7 +134,7 @@ export const useExerciseStore = defineStore('exercise', {
     loadingContent: false,
     error: null,
     loadingChildrenIds: [],
-    allValidators: []
+    allValidators: [],
     selectedAuthorId: null,
     selectedLicenseId: null,
     selectedItemTypeId: null,

--- a/frontend/tests/feature/aufgabendatenbank/validation.test.ts
+++ b/frontend/tests/feature/aufgabendatenbank/validation.test.ts
@@ -125,7 +125,9 @@ describe('validateTreeData', () => {
     expect(issues[0].message).toContain('kein Collection-Item')
   })
 
-  it('flags a duplicate item appearing in rootItems and inside a collection', () => {
+  it('does not flag an item appearing in rootItems and inside a collection', () => {
+    // Sub-Items behalten root_item_id=null und tauchen daher regulär in beiden
+    // Listen auf — das ist kein Fehler und darf keine Meldung erzeugen.
     const dup = item({ id: 'dup', rootItemId: null })
     const data = [
       dup,
@@ -138,7 +140,7 @@ describe('validateTreeData', () => {
     ]
     const issues = validateTreeData(data)
     const dupIssue = issues.find((i) => i.message.includes('sowohl in rootItems als auch in einer Kollektion'))
-    expect(dupIssue).toBeDefined()
+    expect(dupIssue).toBeUndefined()
   })
 
   it('flags a dangling rootItemId reference', () => {


### PR DESCRIPTION
Der Merge von #74 hatte den Build zerlegt:
- fehlendes Komma nach allValidators im State (Syntaxfehler)
- uploadBlob doppelt in adbApi.service, dev-adb-api.service und im ApiAdapter-Interface (Duplicate function implementation)
- validation.test.ts noch auf die entfernte Duplikat-Pruefung eingestellt

type-check und Tests (22/22) wieder gruen.