### PR TITLE
ci: Docker-Images (Backend + Frontend) 

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,62 @@
+# Baut die Docker-Images (Backend + Frontend) und veröffentlicht sie in der
+# GitHub Container Registry (GHCR). Läuft NUR, wenn Code in main landet
+# (also wenn ein Pull Request in main gemergt wird). So gelangt nur
+# geprüfter, stabiler Code auf die Plattform.
+name: Build & Push Images (GHCR)
+
+on:
+  push:
+    branches: [main]
+
+# Der automatische GITHUB_TOKEN braucht Schreibrecht auf Packages (GHCR).
+permissions:
+  contents: read
+  packages: write
+
+# Läuft ein neuer Push, wird ein noch laufender Build abgebrochen.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Eine Anwendung = ein Image. Jede hat ihren eigenen Build-Kontext.
+        app:
+          - name: backend
+            context: ./backend
+          - name: frontend
+            context: ./frontend
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      # GHCR verlangt Image-Namen in Kleinbuchstaben; der Repo-Name enthält
+      # Großbuchstaben (PWI), daher hier klein umwandeln.
+      - name: Image-Namen (lowercase) bestimmen
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')-${{ matrix.app.name }}" >> "$GITHUB_ENV"
+
+      - name: An GHCR anmelden
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx einrichten
+        uses: docker/setup-buildx-action@v3
+
+      - name: Image bauen und pushen (${{ matrix.app.name }})
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.app.context }}
+          push: true
+          # Zwei Tags: 'latest' (immer neueste main) und der Commit-SHA
+          # (eindeutig, für reproduzierbares Deployment via ArgoCD).
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION

GitHub-Actions-Workflow: baut beide Images via matrix und veroeffentlicht sie in der GitHub Container Registry (ghcr.io/<repo>-backend|-frontend), getaggt mit latest und Commit-SHA. Laeuft nur bei push auf main (also nach PR-Merge). Nutzt den automatischen GITHUB_TOKEN (packages: write), mit Build-Cache.