### PR TITLE
feat(k8s): values.yaml fuer Backend und Frontend

### DIFF
--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -1,0 +1,31 @@
+# values.yaml – Backend (Aufgabendatenbank)
+#
+# Konfigurationsblatt fuer ArgoCD: verbindet unser in GHCR gebautes Backend-Image
+# mit dem Kubernetes-Cluster. Legt fest, wie der Service im Cluster heisst, wie
+# viele Replicas er bekommt und unter welchem Netzwerkpfad ihn das Traefik-Gateway
+# veroeffentlicht.
+#
+# Hinweis: Das genaue Schema wird noch an die Vorgabe des Infra-Teams (Gruppe 1)
+# angepasst, sobald deren Registrierungsformat final ist.
+
+name: pwi-aufgabendatenbank-backend
+
+image:
+  repository: ghcr.io/giovanna-creator/pwi-aufgabendatenbank-backend
+  tag: latest
+
+replicas: 1
+
+# Port, auf dem Spring Boot im Container lauscht.
+containerPort: 8080
+
+# Netzwerkpfad, unter dem das API-Gateway (Traefik) den Service erreichbar macht.
+route:
+  path: /api
+
+# Datenbank-Anbindung. Werte als Kubernetes-Secret hinterlegen, nicht im Klartext.
+# Offen: DB von der Plattform gestellt oder selbst deployen? -> mit Gruppe 1 klaeren.
+env:
+  DB_URL: jdbc:postgresql://<db-host>:5432/pwi_aufgabendatenbank
+  DB_USER: postgres
+  DB_PASSWORD: <secret>

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -1,0 +1,19 @@
+# values.yaml – Frontend (Aufgabendatenbank)
+#
+# Siehe backend/values.yaml. Zeigt auf das in GHCR gebaute Frontend-Image.
+# Hinweis: Schema wird noch an die Vorgabe von Gruppe 1 angepasst.
+
+name: pwi-aufgabendatenbank-frontend
+
+image:
+  repository: ghcr.io/giovanna-creator/pwi-aufgabendatenbank-frontend
+  tag: latest
+
+replicas: 1
+
+# Port, auf dem der Frontend-Container lauscht.
+containerPort: 8085
+
+# Frontend liegt am Wurzelpfad; /api leitet das Gateway an das Backend weiter.
+route:
+  path: /


### PR DESCRIPTION
Konfigurationsblatt fuer ArgoCD je App (Name, Image aus GHCR, Replicas, Netzwerkpfad ueber das Traefik-Gateway). Format noch provisorisch, wird an die Vorgabe von Gruppe 1 angepasst.