### PR TITLE
Fix: Varianten/Kollektionen sauber trennen + convertToCollection idempotent

### DIFF
--- a/backend/src/main/java/com/datenbank/backend/service/ItemService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ItemService.java
@@ -232,10 +232,14 @@ public class ItemService {
     public ItemResponseDto convertToCollection(UUID itemId) {
         Item item = findItemOrThrow(itemId);
 
-        ItemCollection collection = new ItemCollection();
-        collection.setParentItem(item);
-        collection.setCollectionOrder(false);
-        collectionRepository.save(collection);
+        // Idempotent: hat das Item bereits eine Kollektion, wird keine zweite
+        // angelegt (verhindert Duplikate bei Doppelklick bzw. Doppel-Request).
+        if (!collectionRepository.existsByParentItem_ItemId(itemId)) {
+            ItemCollection collection = new ItemCollection();
+            collection.setParentItem(item);
+            collection.setCollectionOrder(false);
+            collectionRepository.save(collection);
+        }
 
         return convertToResponseDto(item);
     }

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -1548,7 +1548,6 @@ export const useExerciseStore = defineStore('exercise', {
             }
           }
         }
-        inner.rootItemId = collection.rootItemId ?? null
         if (isCollectionItem(item)) {
           return { ...item, collectionId: collection.id, position: collection.order ? index + 1 : null } as CollectionItem
         }


### PR DESCRIPTION

Beim Verschieben eines Items in eine Kollektion wird rootItemId (Variantenbezug) nicht mehr überschrieben → vertikale und horizontale Beziehung bleiben getrennt.
convertToCollection legt keine zweite ItemCollection mehr an, wenn das Item bereits eine hat (verhindert Duplikate).