### PR TITLE
Fix: create/delete gegen Teilfehler absichern (Resync statt Divergenz)

### DIFF
--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -1087,6 +1087,10 @@ export const useExerciseStore = defineStore('exercise', {
       } catch (e) {
         this._notifyError(e)
         this.variants = this.variants.filter((v) => v !== variant)
+        // Konvergiert zur DB-Wahrheit: falls Stufe 1 (createItem) doch
+        // durchlief und erst createContent scheiterte, taucht das Item hier
+        // wieder auf, statt als Waise zu verschwinden.
+        await this.loadVariants(baseItemId)
       }
     },
 
@@ -1206,6 +1210,16 @@ export const useExerciseStore = defineStore('exercise', {
       return null
     },
 
+    /**
+     * Nach einem fehlgeschlagenen optimistischen Write den betroffenen
+     * Teilbaum wieder mit dem DB-Stand abgleichen. Bevorzugt der schmale
+     * Reload einer Kollektion; Fallback: kompletter Baum-Reload.
+     */
+    _resyncAggregate(target?: Collection | null): Promise<void> {
+      if (target?.collectionId) return this._loadChildrenRecursively([target])
+      return this.loadTree()
+    },
+
     /** Build a minimal Item object with a unique ID and single Content block. */
     _createItemData(rootItemId: string | null = null): Item {
       const now = Date.now().toString()
@@ -1309,31 +1323,36 @@ export const useExerciseStore = defineStore('exercise', {
     createItem(rootItemId: string | null = null, addToRoot = true, onCreated?: (realId: string) => void): Item {
       const item = this._createItemData(rootItemId)
       if (addToRoot) this.rootItems.push(item)
-      _adapter?.createItem({
-        authorId: item.authorId ?? this.defaultAuthorId,
-        licenseId: item.licenseId ?? this.defaultLicenseId,
-        itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
-        rootItemId: item.rootItemId ?? null
-      }).then((dto) => {
-        if (dto) {
+      void (async () => {
+        try {
+          const dto = await _adapter!.createItem({
+            authorId: item.authorId ?? this.defaultAuthorId,
+            licenseId: item.licenseId ?? this.defaultLicenseId,
+            itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
+            rootItemId: item.rootItemId ?? null
+          })
           item.id = dto.itemId
           onCreated?.(dto.itemId)
           if (item.contents.length > 0) {
             const c0 = item.contents[0]
-            _adapter?.createContent(dto.itemId, {
+            const contentDto = await _adapter!.createContent(dto.itemId, {
               licenseId: c0.licenseId ?? this.defaultLicenseId,
               itemContentTypeId: c0.contentTypeId ?? this.defaultContentTypeId,
               authorId: c0.authorId ?? this.defaultAuthorId,
               purpose: c0.purpose,
               jsonSerializedContent: JSON.stringify(c0.jsonContent)
-            }).then((contentDto) => {
-              if (contentDto && item.contents[0]) {
-                item.contents[0].id = contentDto.itemContentId
-              }
-            }).catch((e) => this._notifyError(e))
+            })
+            if (contentDto && item.contents[0]) {
+              item.contents[0].id = contentDto.itemContentId
+            }
           }
+        } catch (e) {
+          // Bei Teilfehler den Baum wieder mit dem DB-Stand abgleichen,
+          // damit kein Geister-Item mit Temp-ID zurückbleibt.
+          this._notifyError(e)
+          await this.loadTree()
         }
-      }).catch((e) => this._notifyError(e))
+      })()
       this.validate()
       return item
     },
@@ -1376,29 +1395,34 @@ export const useExerciseStore = defineStore('exercise', {
         this.rootItems.push(item)
       }
 
-      _adapter?.createItem({
-        authorId: item.authorId ?? this.defaultAuthorId,
-        licenseId: item.licenseId ?? this.defaultLicenseId,
-        itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
-        rootItemId: item.rootItemId ?? null
-      }).then((dto) => {
-        if (!dto) return
-        item.id = dto.itemId
-        _adapter?.createContent(dto.itemId, {
-          licenseId: c0.licenseId ?? this.defaultLicenseId,
-          itemContentTypeId: c0.contentTypeId ?? this.defaultContentTypeId,
-          authorId: c0.authorId ?? this.defaultAuthorId,
-          purpose: c0.purpose,
-          jsonSerializedContent: JSON.stringify(c0.jsonContent)
-        }).then((contentDto) => {
+      void (async () => {
+        try {
+          const dto = await _adapter!.createItem({
+            authorId: item.authorId ?? this.defaultAuthorId,
+            licenseId: item.licenseId ?? this.defaultLicenseId,
+            itemTypeId: item.itemTypeId ?? this.defaultItemTypeId,
+            rootItemId: item.rootItemId ?? null
+          })
+          item.id = dto.itemId
+          const contentDto = await _adapter!.createContent(dto.itemId, {
+            licenseId: c0.licenseId ?? this.defaultLicenseId,
+            itemContentTypeId: c0.contentTypeId ?? this.defaultContentTypeId,
+            authorId: c0.authorId ?? this.defaultAuthorId,
+            purpose: c0.purpose,
+            jsonSerializedContent: JSON.stringify(c0.jsonContent)
+          })
           if (contentDto) c0.id = contentDto.itemContentId
-        }).catch((e) => this._notifyError(e))
-        if (target && target.collectionId) {
-          _adapter?.addItemToCollection(target.collectionId, dto.itemId)
-            .catch((e) => this._notifyError(e))
+          if (target?.collectionId) {
+            await _adapter!.addItemToCollection(target.collectionId, dto.itemId)
+          }
+          this.selectItem(collectionItem ?? item)
+        } catch (e) {
+          // Schlägt eine der Stufen fehl, den betroffenen Aggregat-Teilbaum
+          // (Ziel-Kollektion oder Baum) wieder mit dem DB-Stand abgleichen.
+          this._notifyError(e)
+          await this._resyncAggregate(target)
         }
-        this.selectItem(collectionItem ?? item)
-      }).catch((e) => this._notifyError(e))
+      })()
 
       if (target) this._syncOrderedCollectionItems(target)
       this.validate()
@@ -1443,22 +1467,26 @@ export const useExerciseStore = defineStore('exercise', {
       // Backend-Modell: erst eine Item anlegen, dann zur Kollektion machen
       // (POST /items → POST /items/{id}/collection). So taucht die Kollektion
       // beim Neuladen über GET /items?root=true wieder auf.
-      _adapter?.createItem({
-        authorId,
-        licenseId,
-        itemTypeId,
-        rootItemId: null
-      })
-        .then((dto) => {
-          if (!dto) return
+      void (async () => {
+        try {
+          const dto = await _adapter!.createItem({
+            authorId,
+            licenseId,
+            itemTypeId,
+            rootItemId: null
+          })
           collection.id = dto.itemId
-          return _adapter?.convertItemToCollection(dto.itemId)
-        })
-        .then((collDto) => {
           // item_collection_id merken — nötig für alle weiteren Collection-Calls
-          if (collDto) collection.collectionId = collDto.collectionId ?? null
-        })
-        .catch((e) => this._notifyError(e))
+          const collDto = await _adapter!.convertItemToCollection(dto.itemId)
+          collection.collectionId = collDto.collectionId ?? null
+        } catch (e) {
+          // Schlägt das Anlegen oder das Umwandeln fehl, bleibt collectionId
+          // null (alle weiteren Collection-Calls würden still übersprungen) —
+          // daher den Baum wieder mit dem DB-Stand abgleichen.
+          this._notifyError(e)
+          await this.loadTree()
+        }
+      })()
       this.validate()
       return collection
     },
@@ -1468,7 +1496,12 @@ export const useExerciseStore = defineStore('exercise', {
       const item = this.createItem(rootId, false, (realId) => {
         if (collection.collectionId) {
           _adapter?.addItemToCollection(collection.collectionId, realId)
-            .catch((e) => this._notifyError(e))
+            .catch(async (e) => {
+              // Verknüpfung fehlgeschlagen → Kollektion mit dem DB-Stand
+              // abgleichen (das lokal eingefügte Item wieder entfernen).
+              this._notifyError(e)
+              await this._resyncAggregate(collection)
+            })
         }
       })
       const collectionItem: CollectionItem = {
@@ -1503,7 +1536,14 @@ export const useExerciseStore = defineStore('exercise', {
       if (this.selectedItem && getInnerItem(this.selectedItem).id === itemId) {
         this.selectedItem = null
       }
-      _adapter?.deleteItem(itemId).catch((e) => this._notifyError(e))
+      // Parent VOR dem async-Gap merken (nach _detachItem ist das Item schon
+      // aus dem lokalen Baum entfernt).
+      const parentForResync = parentId ? this._findCollectionById(parentId) : null
+      _adapter?.deleteItem(itemId).catch(async (e) => {
+        // Löschen fehlgeschlagen → das Item wieder aus dem DB-Stand herstellen.
+        this._notifyError(e)
+        await this._resyncAggregate(parentForResync)
+      })
       if (parentId) {
         const parent = this._findCollectionById(parentId)
         if (parent) this._syncOrderedCollectionItems(parent)

--- a/frontend/tests/feature/aufgabendatenbank/store.test.ts
+++ b/frontend/tests/feature/aufgabendatenbank/store.test.ts
@@ -789,3 +789,131 @@ describe('createReference', () => {
     expect(mock.createAuthor).not.toHaveBeenCalled()
   })
 })
+
+describe('resync on partial failure (create/delete)', () => {
+  function seedRefs(store: ReturnType<typeof useExerciseStore>) {
+    store.authors = [DEFAULT_AUTHOR]
+    store.itemTypes = [DEFAULT_ITEM_TYPE]
+    store.contentTypes = [DEFAULT_CONTENT_TYPE]
+  }
+
+  const collTarget = () => ({
+    id: 'coll-1',
+    collectionId: 'coll-backend-1',
+    item_type: 'collection' as const,
+    items: [] as any[],
+    order: false,
+    author: 'test',
+    representationTemplate: null,
+    license: null,
+    tags: [],
+    validators: [],
+    modifiers: [],
+    contents: [],
+    rootItemId: null
+  })
+
+  it('createItem: step-1 failure removes the phantom item', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getRootItems = vi.fn().mockResolvedValue([])
+
+    store.createItem(null, true)
+    expect(store.rootItems).toHaveLength(1) // optimistisch sofort da
+
+    await vi.waitFor(() => expect(store.rootItems).toHaveLength(0)) // resynct weg
+    expect(mock.getRootItems).toHaveBeenCalled()
+  })
+
+  it('createItem: content-step failure converges rootItems to the DB', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockResolvedValue({ itemId: 'real-id' } as ItemDTO)
+    mock.createContent = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getRootItems = vi.fn().mockResolvedValue([{ itemId: 'real-id' } as ItemDTO])
+
+    store.createItem(null, true)
+
+    await vi.waitFor(() => {
+      expect(mock.getRootItems).toHaveBeenCalled()
+      expect(store.rootItems).toHaveLength(1)
+      expect(store.rootItems[0].id).toBe('real-id')
+    })
+  })
+
+  it('createItemFromForm: add-to-collection failure resyncs the collection', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockResolvedValue({ itemId: 'form-item' } as ItemDTO)
+    mock.addItemToCollection = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getCollectionItems = vi.fn().mockResolvedValue([])
+
+    const target = collTarget()
+    store.rootItems.push(target)
+
+    store.createItemFromForm({ text: 'x' }, target)
+    expect(target.items).toHaveLength(1) // optimistisch
+
+    await vi.waitFor(() => expect(target.items).toHaveLength(0)) // resynct
+    expect(mock.getCollectionItems).toHaveBeenCalledWith('coll-backend-1')
+  })
+
+  it('createCollection: convert failure resyncs the tree', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockResolvedValue({ itemId: 'real-id' } as ItemDTO)
+    mock.convertItemToCollection = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getRootItems = vi.fn().mockResolvedValue([])
+
+    store.createCollection()
+    expect(store.rootItems).toHaveLength(1) // optimistisch
+
+    await vi.waitFor(() => expect(store.rootItems).toHaveLength(0)) // resynct via loadTree
+    expect(mock.getRootItems).toHaveBeenCalled()
+  })
+
+  it('addItemToCollection: link failure resyncs the collection', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockResolvedValue({ itemId: 'new-item' } as ItemDTO)
+    mock.addItemToCollection = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getCollectionItems = vi.fn().mockResolvedValue([])
+
+    const coll = collTarget()
+    store.rootItems.push(coll)
+
+    store.addItemToCollection(coll as any)
+    expect(coll.items).toHaveLength(1) // optimistisch
+
+    await vi.waitFor(() => expect(coll.items).toHaveLength(0)) // resynct
+    expect(mock.getCollectionItems).toHaveBeenCalledWith('coll-backend-1')
+  })
+
+  it('deleteItem: delete failure restores the item from the DB', async () => {
+    const store = useExerciseStore()
+    const item: any = { id: 'x', item_type: 'exercise', contents: [], tags: [], validators: [], modifiers: [], author: 'a', representationTemplate: null, license: null }
+    store.rootItems.push(item)
+    mock.deleteItem = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getRootItems = vi.fn().mockResolvedValue([{ itemId: 'x' } as ItemDTO])
+
+    store.deleteItem(item)
+    expect(store.rootItems).toHaveLength(0) // optimistisch entfernt
+
+    await vi.waitFor(() => expect(store.rootItems).toHaveLength(1)) // wiederhergestellt
+    expect(store.rootItems[0].id).toBe('x')
+  })
+
+  it('createVariant: content-step failure resyncs variants instead of orphaning', async () => {
+    const store = useExerciseStore()
+    seedRefs(store)
+    mock.createItem = vi.fn().mockResolvedValue({ itemId: 'variant-real' } as ItemDTO)
+    mock.createContent = vi.fn().mockRejectedValue(new Error('boom'))
+    mock.getItemsByRootId = vi.fn().mockResolvedValue([])
+
+    await store.createVariant('base')
+
+    expect(mock.getItemsByRootId).toHaveBeenCalledWith('base')
+    expect(store.variants).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Optimistische Create/Delete-Flows glichen bei einem Teilfehler den lokalen Zustand nicht mit der DB ab (Geister-Items mit Temp-ID, nie verknüpfte Kollektionen). Neuer Helfer _resyncAggregate lädt bei Fehler den betroffenen Teilbaum neu und konvergiert zum DB-Stand. Signaturen bleiben synchron, keine Aufrufer-Änderung. +7 Tests.