### PR TITLE
Fix: Kollektions-Konsistenz (Positionen + rootItemId)

### DIFF
--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -753,9 +753,9 @@ export const useExerciseStore = defineStore('exercise', {
     /**
      * Toggle a collection's `order` flag.
      *
-     * Positions are KEPT in the data when order toggles off (the UI
-     * simply hides them). When enabling, items without a position get
-     * one assigned.
+     * When enabling, items without a position get one assigned. When
+     * disabling, positions are cleared to null to match the backend
+     * (which nulls them), so UI and DB stay in sync.
      */
     toggleCollectionOrder(collection: Collection) {
       collection.order = !collection.order
@@ -764,6 +764,12 @@ export const useExerciseStore = defineStore('exercise', {
           if (item.position == null) {
             item.position = index + 1
           }
+        })
+      } else {
+        // Backend setzt die Positionen auf NULL, wenn die Reihenfolge
+        // deaktiviert wird — lokal nachziehen, damit UI und DB nicht divergieren.
+        collection.items.forEach((item) => {
+          item.position = null
         })
       }
       if (collection.collectionId) {
@@ -1520,7 +1526,9 @@ export const useExerciseStore = defineStore('exercise', {
       this.deleteItem(collectionToDelete)
       // Enthaltene Aufgaben nicht loeschen, sondern auf die Root-Ebene heben.
       children.forEach((child) => {
-        child.rootItemId = null
+        // rootItemId NICHT anfassen: das ist der Varianten-Bezug (horizontal),
+        // orthogonal zur Kollektions-Zugehoerigkeit. Nullen wuerde die
+        // Varianten-Beziehung einer Aufgabe zerstoeren.
         if (!this.rootItems.some((ri) => ri.id === child.id)) {
           this.rootItems.push(child)
         }

--- a/frontend/tests/feature/aufgabendatenbank/store.test.ts
+++ b/frontend/tests/feature/aufgabendatenbank/store.test.ts
@@ -432,7 +432,7 @@ describe('toggleCollectionOrder', () => {
     expect(coll.items[1].position).toBe(2)
   })
 
-  it('disables order (keeps positions intact)', () => {
+  it('disables order (clears positions to match backend)', () => {
     const store = useExerciseStore()
     const coll: any = {
       id: 'coll-1',
@@ -448,7 +448,9 @@ describe('toggleCollectionOrder', () => {
     store.toggleCollectionOrder(coll)
 
     expect(coll.order).toBe(false)
-    expect(coll.items[0].position).toBe(1)
+    // Backend nullt die Positionen bei Deaktivierung — lokal muss es passen.
+    expect(coll.items[0].position).toBeNull()
+    expect(coll.items[1].position).toBeNull()
   })
 
   it('calls adapter.toggleCollectionOrder when collectionId is set', () => {
@@ -513,6 +515,32 @@ describe('deleteItem and deleteCollection', () => {
     // wird auf die Root-Ebene gehoben.
     expect(store.rootItems.length).toBe(1)
     expect(store.rootItems[0].id).toBe('child')
+  })
+
+  it('deleteCollection keeps a child variant relationship (rootItemId untouched)', () => {
+    const store = useExerciseStore()
+    // Das Kind ist selbst eine Variante (rootItemId gesetzt).
+    const child: any = { id: 'child', item_type: 'exercise', rootItemId: 'variant-family', contents: [], tags: [], validators: [], modifiers: [], author: 'a', representationTemplate: null, license: null }
+    const coll: any = {
+      id: 'coll-del',
+      item_type: 'collection',
+      contents: [],
+      tags: [],
+      validators: [],
+      modifiers: [],
+      author: 'a',
+      representationTemplate: null,
+      license: null,
+      items: [{ id: 'ci-del', collectionId: 'coll-del', item: child, position: null }],
+      order: false
+    }
+    store.rootItems.push(coll)
+
+    store.deleteCollection(coll)
+
+    // Das Aufloesen der Kollektion darf den Varianten-Bezug nicht zerstoeren.
+    expect(store.rootItems[0].id).toBe('child')
+    expect(store.rootItems[0].rootItemId).toBe('variant-family')
   })
 })
 


### PR DESCRIPTION
toggleCollectionOrder nullt beim Deaktivieren die Positionen lokal (wie das Backend).
deleteCollection fasst rootItemId der Kinder nicht mehr an (Varianten-Bezug bleibt erhalten). +Tests.