### PR TITLE
feat(ui): Dark-/Light-Mode Umschaltung mit Theme-Variablen

### DIFF
--- a/backend/src/main/java/com/datenbank/backend/controller/ItemController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ItemController.java
@@ -12,9 +12,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * REST-Controller für die Item-Entität.
- */
 @RestController
 @RequestMapping("/api/items")
 @CrossOrigin(origins = "*")
@@ -26,19 +23,16 @@ public class ItemController {
         this.itemService = itemService;
     }
 
-    // GET /api/items/{id}
     @GetMapping("/{id}")
     public ResponseEntity<ItemResponseDto> getById(@PathVariable UUID id) {
         return ResponseEntity.ok(itemService.getItemById(id));
     }
 
-    // POST /api/items
     @PostMapping
     public ResponseEntity<ItemResponseDto> create(@Valid @RequestBody ItemCreateDto dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(itemService.createItem(dto));
     }
 
-    // PUT /api/items/{id}
     @PutMapping("/{id}")
     public ResponseEntity<ItemResponseDto> update(
             @PathVariable UUID id,
@@ -46,28 +40,17 @@ public class ItemController {
         return ResponseEntity.ok(itemService.updateItem(id, dto));
     }
 
-    // DELETE /api/items/{id}
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         itemService.deleteItem(id);
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Konvertiert ein Item in eine Collection.
-     * POST /api/items/{id}/collection → 200 OK
-     */
     @PostMapping("/{id}/collection")
     public ResponseEntity<ItemResponseDto> convertToCollection(@PathVariable UUID id) {
         return ResponseEntity.ok(itemService.convertToCollection(id));
     }
 
-    /**
-     * GET /api/items                        → alle Items
-     * GET /api/items?root=true              → nur Root-Items
-     * GET /api/items?rootItemId=5           → Kinder von Item 5
-     * GET /api/items?search=&authorId=&itemTypeId=&tag= → gefilterte Items
-     */
     @GetMapping
     public ResponseEntity<List<ItemResponseDto>> getAll(
             @RequestParam(required = false) Boolean root,
@@ -100,24 +83,12 @@ public class ItemController {
         return s != null && !s.trim().isEmpty();
     }
 
-    // =========================================================================
-    // Validator-Verknüpfungen
-    // =========================================================================
-
-    /**
-     * Liefert alle Validatoren, die mit einem Item verknüpft sind.
-     * GET /api/items/{itemId}/validators
-     */
     @GetMapping("/{itemId}/validators")
     public ResponseEntity<List<ValidatorResponseDto>> getValidatorsForItem(
             @PathVariable UUID itemId) {
         return ResponseEntity.ok(itemService.getValidatorsForItem(itemId));
     }
 
-    /**
-     * Verknüpft einen Validator mit einem Item.
-     * POST /api/items/{itemId}/validators/{validatorId}
-     */
     @PostMapping("/{itemId}/validators/{validatorId}")
     public ResponseEntity<ItemResponseDto> addValidatorToItem(
             @PathVariable UUID itemId,
@@ -125,10 +96,6 @@ public class ItemController {
         return ResponseEntity.ok(itemService.addValidatorToItem(itemId, validatorId));
     }
 
-    /**
-     * Entfernt die Verknüpfung eines Validators von einem Item.
-     * DELETE /api/items/{itemId}/validators/{validatorId}
-     */
     @DeleteMapping("/{itemId}/validators/{validatorId}")
     public ResponseEntity<Void> removeValidatorFromItem(
             @PathVariable UUID itemId,
@@ -137,11 +104,6 @@ public class ItemController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Tag an ein Item hängen bzw. wieder entfernen.
-     * POST   /api/items/{id}/tags         Body { "tagId": "..." }
-     * DELETE /api/items/{id}/tags/{tagId}
-     */
     public record TagAssign(UUID tagId) {}
 
     @PostMapping("/{id}/tags")

--- a/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
+++ b/backend/src/main/java/com/datenbank/backend/controller/ReferenceController.java
@@ -91,7 +91,7 @@ public class ReferenceController {
                 .toList();
     }
 
-    // ── Anlegen neuer Referenzdaten ──────────────────────────────────────────
+
 
     @PostMapping("/authors")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/datenbank/backend/dto/ItemResponseDto.java
+++ b/backend/src/main/java/com/datenbank/backend/dto/ItemResponseDto.java
@@ -8,76 +8,39 @@ import java.util.Set;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * DTO für die Rückgabe einer Aufgabe (Item) an das Frontend.
- *
- * Wird vom Backend an das Frontend gesendet bei:
- *  - GET  /api/items
- *  - GET  /api/items/{id}
- *  - POST /api/items (Antwort nach Erstellung)
- *  - PUT  /api/items/{id} (Antwort nach Aktualisierung)
- *
- * Enthält die itemId und die generierten Timestamps.
- * Die verknüpften Entitäten (Author, License, etc.) werden mit ihrem
- * lesbaren Namen ausgegeben, nicht nur als ID — bequemer für das Frontend.
- */
+/** DTO für die Rückgabe einer Aufgabe (Item) — mit lesbaren Namen der verknüpften Entitäten. */
 public class ItemResponseDto {
 
     private UUID itemId;
 
-    // Author
     private UUID authorId;
     private String authorDescriptor;
 
-    // License
     private UUID licenseId;
     private String licenseName;
 
-    // ItemType
     private UUID itemTypeId;
     private String itemTypeName;
 
-    // Optional: Template
     private UUID itemTemplateId;
 
-    // Optional: Ursprungs-Aufgabe
     private UUID rootItemId;
 
-    // Verknüpfte Tags, Validatoren, Modifier (nur IDs für Einfachheit)
     private Set<UUID> tagIds = new HashSet<>();
     private Set<UUID> validatorIds = new HashSet<>();
     private Set<UUID> modifierIds = new HashSet<>();
 
-    // Timestamps (vom System gesetzt)
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     
 
-    /**
-     * true wenn dieses Item eine Kollektion ist
-     * (d.h. eine ItemCollection mit parent_item_id = item_id existiert)
-     */
     private boolean isCollection;
 
-    /**
-     * Reihenfolge-Flag, falls dieses Item eine Kollektion ist.
-     * true = geordnet, false = ungeordnet, null = keine Kollektion.
-     * Damit das Frontend den Order-Status auch beim Laden über /items kennt.
-     */
     private Boolean order;
 
-    /**
-     * Die item_collection_id, falls dieses Item eine Kollektion ist (sonst null).
-     * Das Frontend braucht sie für alle /api/collections/{id}/... Aufrufe,
-     * da diese Endpunkte über die Collection-ID adressiert werden, nicht über
-     * die item_id.
-     */
     private UUID collectionId;
 
-    /**
-     * Inhalte dieses Items. Niemals null — leere Liste wenn keine vorhanden.
-     */
     private List<ContentSummaryDto> contents = new ArrayList<>();
 
     // Getter & Setter

--- a/backend/src/main/java/com/datenbank/backend/entity/Item.java
+++ b/backend/src/main/java/com/datenbank/backend/entity/Item.java
@@ -6,16 +6,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * Entspricht der Tabelle "item" - die zentrale Aufgaben-Entität.
- *
- * Beziehungen:
- *  - @ManyToOne zu Author, License, ItemType, ItemRepresentationTemplate
- *  - Self-Reference: root_item_id (für Varianten)
- *  - @ManyToMany zu Tag (über item_tags)
- *  - @ManyToMany zu Validator (über item_validator)
- *  - @ManyToMany zu Modifier (über item_modifier)
- */
 @Entity
 @Table(name = "item")
 public class Item {
@@ -37,17 +27,10 @@ public class Item {
     @JoinColumn(name = "item_type_id", nullable = false)
     private ItemType itemType;
 
-    /**
-     * Optionales Template (kann null sein -> ON DELETE SET NULL im Schema).
-     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_template_id")
     private ItemRepresentationTemplate itemTemplate;
 
-    /**
-     * Self-Reference: Varianten verweisen auf ihre Ursprungs-Aufgabe.
-     * @ManyToOne weil viele Varianten dasselbe Original haben können.
-     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "root_item_id")
     private Item rootItem;
@@ -58,11 +41,6 @@ public class Item {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    /**
-     * @ManyToMany zu Tag über die Join-Tabelle "item_tags".
-     * Diese Join-Tabelle hat KEINE zusätzlichen Attribute,
-     * daher reicht @ManyToMany ohne eigene Entity-Klasse.
-     */
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "item_tags",

--- a/backend/src/main/java/com/datenbank/backend/entity/ItemCollectionSubItem.java
+++ b/backend/src/main/java/com/datenbank/backend/entity/ItemCollectionSubItem.java
@@ -2,16 +2,7 @@ package com.datenbank.backend.entity;
 
 import jakarta.persistence.*;
 
-/**
- * Entspricht der Tabelle "item_collection_sub_item".
- *
- * Diese Join-Tabelle hat ein zusätzliches Attribut "position"
- * (die Reihenfolge der Aufgabe in der Sequenz), daher braucht sie
- * eine eigene Entity-Klasse mit Composite Key (statt @ManyToMany).
- *
- * @MapsId verknüpft die Teile des Composite Keys mit den
- * jeweiligen @ManyToOne-Beziehungen.
- */
+/** Join-Tabelle mit zusätzl. "position"-Attribut → eigene Entity + Composite Key nötig. */
 @Entity
 @Table(name = "item_collection_sub_item")
 public class ItemCollectionSubItem {
@@ -19,10 +10,6 @@ public class ItemCollectionSubItem {
     @EmbeddedId
     private ItemCollectionSubItemId id;
 
-    /**
-     * @MapsId("itemCollectionId"): verbindet das Feld itemCollectionId
-     * des Composite Keys mit dieser Beziehung.
-     */
     @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("itemCollectionId")
     @JoinColumn(name = "item_collection_id")

--- a/backend/src/main/java/com/datenbank/backend/entity/ItemContent.java
+++ b/backend/src/main/java/com/datenbank/backend/entity/ItemContent.java
@@ -8,14 +8,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * Entspricht der Tabelle "item_content".
- * Inhaltsbausteine der Aufgaben (Text, JSON, Binärdaten).
- *
- * Beziehungen:
- *  - @ManyToOne zu License, ItemContentType, Author (Level-1-Entitäten)
- *  - @ManyToMany zu Tag (über item_content_tags)
- */
 @Entity
 @Table(name = "item_content")
 public class ItemContent {
@@ -25,9 +17,6 @@ public class ItemContent {
     @Column(name = "item_content_id")
     private UUID itemContentId;
 
-    /**
-     * FK auf license. @ManyToOne: viele Contents können dieselbe Lizenz haben.
-     */
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "license_id", nullable = false)
     private License license;
@@ -40,21 +29,10 @@ public class ItemContent {
     @JoinColumn(name = "author_id", nullable = false)
     private Author author;
 
-    /**
-     * JSONB-Spalte. Wir mappen sie als String mit columnDefinition = "jsonb".
-     * Hibernate liest/schreibt den JSON-Text; für die meisten Anwendungsfälle
-     * ausreichend. Bei Bedarf später auf hibernate-types umstellbar.
-     */
-    
-
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "json_serialized_content", columnDefinition = "jsonb")
     private String jsonSerializedContent;
 
-    /**
-     * BYTEA-Spalte für Binärdaten (Bilder, PDFs).
-     */
-    
     @Column(name = "blob_serialized_content")
     private byte[] blobSerializedContent;
 
@@ -64,10 +42,6 @@ public class ItemContent {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    /**
-     * @ManyToMany zu Tag über die Join-Tabelle "item_content_tags".
-     * Keine zusätzlichen Attribute -> @ManyToMany ohne eigene Klasse.
-     */
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "item_content_tags",
@@ -76,9 +50,6 @@ public class ItemContent {
     )
     private Set<Tag> tags = new HashSet<>();
 
-    /**
-     * Wird automatisch vor dem Speichern gesetzt.
-     */
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/backend/src/main/java/com/datenbank/backend/entity/Tag.java
+++ b/backend/src/main/java/com/datenbank/backend/entity/Tag.java
@@ -13,10 +13,6 @@ public class Tag {
     @Column(name = "tag_id")
     private UUID tagId;
 
-    /**
-     * Self-Reference: ein Tag kann ein Eltern-Tag haben.
-     * @ManyToOne weil viele Tags dasselbe Eltern-Tag haben können.
-     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_tag_id")
     private Tag parentTag;

--- a/backend/src/main/java/com/datenbank/backend/entity/Validator.java
+++ b/backend/src/main/java/com/datenbank/backend/entity/Validator.java
@@ -3,10 +3,6 @@ package com.datenbank.backend.entity;
 import jakarta.persistence.*;
 import java.util.UUID;
 
-/**
- * Entspricht der Tabelle "validator".
- * Validatoren für Aufgaben (z.B. "muss INNER JOIN enthalten").
- */
 @Entity
 @Table(name = "validator")
 public class Validator {

--- a/backend/src/main/java/com/datenbank/backend/service/ItemCollectionService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ItemCollectionService.java
@@ -15,14 +15,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-/**
- * Service-Schicht für die Geschäftslogik der ItemCollection-Entität.
- *
- * Aufgaben:
- *  - Umwandlung zwischen DTOs (Frontend) und Entities (Datenbank)
- *  - Verwaltung von Sub-Items mit Position
- *  - CRUD-Operationen mit korrekter Fehlerbehandlung
- */
 @Service
 public class ItemCollectionService {
 
@@ -30,9 +22,6 @@ public class ItemCollectionService {
     private final ItemRepository itemRepository;
     private final ItemCollectionSubItemRepository subItemRepository;
 
-    /**
-     * Constructor-Injection: Spring übergibt automatisch die Repositories.
-     */
     public ItemCollectionService(
             ItemCollectionRepository collectionRepository,
             ItemRepository itemRepository,
@@ -43,12 +32,6 @@ public class ItemCollectionService {
     }
 
 
-    // CRUD-Operationen
-
-
-    /**
-     * Liefert alle Kollektionen als Liste von ResponseDTOs.
-     */
     @Transactional(readOnly = true)
     public List<ItemCollectionResponseDto> getAll() {
         return collectionRepository.findAll().stream()
@@ -56,9 +39,6 @@ public class ItemCollectionService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Liefert alle Root-Kollektionen (ohne Eltern-Item).
-     */
     @Transactional(readOnly = true)
     public List<ItemCollectionResponseDto> getRootCollections() {
         return collectionRepository.findByParentItemIsNull().stream()
@@ -66,19 +46,12 @@ public class ItemCollectionService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Liefert eine einzelne Kollektion als ResponseDTO.
-     * Wirft 404, falls nicht gefunden.
-     */
     @Transactional(readOnly = true)
     public ItemCollectionResponseDto getById(UUID id) {
         ItemCollection collection = findCollectionOrThrow(id);
         return convertToResponseDto(collection);
     }
 
-    /**
-     * Erstellt eine neue Kollektion aus einem CreateDTO.
-     */
     @Transactional
     public ItemCollectionResponseDto create(ItemCollectionCreateDto dto) {
         ItemCollection collection = new ItemCollection();
@@ -87,10 +60,6 @@ public class ItemCollectionService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Aktualisiert eine existierende Kollektion.
-     * Wirft 404, falls die Kollektion nicht existiert.
-     */
     @Transactional
     public ItemCollectionResponseDto update(
             UUID id, ItemCollectionCreateDto dto) {
@@ -100,10 +69,6 @@ public class ItemCollectionService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Löscht eine Kollektion samt Sub-Items (CASCADE).
-     * Wirft 404, falls nicht gefunden.
-     */
     @Transactional
     public void delete(UUID id) {
         if (!collectionRepository.existsById(id)) {
@@ -113,11 +78,7 @@ public class ItemCollectionService {
         collectionRepository.deleteById(id);
     }
 
-    /**
-     * Schaltet die Reihenfolge einer Kollektion um.
-     * true → geordnet (Positionen 1, 2, 3...)
-     * false → ungeordnet (Positionen null)
-     */
+    /** true → geordnet (Positionen 1, 2, 3…), false → ungeordnet (Positionen null) */
     @Transactional
     public ItemCollectionResponseDto toggleOrder(UUID collectionId, Boolean newOrder) {
         ItemCollection collection = findCollectionOrThrow(collectionId);
@@ -134,10 +95,6 @@ public class ItemCollectionService {
         return convertToResponseDto(collectionRepository.save(collection));
     }
 
-    /**
-     * Aktualisiert die Position eines SubItems in einer Kollektion.
-     * Berechnet die Positionen aller Geschwister-Items neu.
-     */
     @Transactional
     public void updateSubItemPosition(UUID collectionId, UUID itemId, Integer newPosition) {
         List<ItemCollectionSubItem> subItems = subItemRepository
@@ -170,10 +127,7 @@ public class ItemCollectionService {
         subItemRepository.saveAll(subItems);
     }
 
-    /**
-     * Fügt ein Item zu einer Kollektion hinzu.
-     * Bei geordneten Collections wird die Position automatisch vergeben.
-     */
+    /** Bei geordneten Collections wird die Position automatisch vergeben. */
     @Transactional
     public CollectionSubItemDto addItemToCollection(UUID collectionId, UUID itemId) {
         ItemCollection collection = findCollectionOrThrow(collectionId);
@@ -197,9 +151,6 @@ public class ItemCollectionService {
         return dto;
     }
 
-    /**
-     * Entfernt ein Item aus einer Kollektion.
-     */
     @Transactional
     public void removeItemFromCollection(UUID collectionId, UUID itemId) {
         List<ItemCollectionSubItem> subItems = subItemRepository
@@ -222,18 +173,10 @@ public class ItemCollectionService {
     }
 
 
-    // Hilfsmethoden
-
-
-    /**
-     * Gibt alle SubItems einer Kollektion zurück, sortiert nach Position.
-     * Wirft 404 wenn Kollektion nicht existiert.
-     */
     @Transactional(readOnly = true)
     public List<CollectionSubItemDto> getSubItemsForCollection(
             UUID collectionId) {
 
-        // Prüfen ob Collection existiert
         if (!collectionRepository.existsById(collectionId)) {
             throw new ResponseStatusException(
                 HttpStatus.NOT_FOUND, "Collection nicht gefunden");
@@ -262,9 +205,6 @@ public class ItemCollectionService {
     }
 
 
-    /**
-     * Holt eine Kollektion aus der DB oder wirft 404.
-     */
     private ItemCollection findCollectionOrThrow(UUID id) {
         return collectionRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(
@@ -272,10 +212,6 @@ public class ItemCollectionService {
     }
 
 
-    /**
-     * Wendet die Daten eines CreateDTO auf eine ItemCollection-Entity an.
-     * Wird sowohl bei Create als auch bei Update verwendet.
-     */
     private void applyDtoToEntity(
             ItemCollectionCreateDto dto, ItemCollection collection) {
 
@@ -318,9 +254,6 @@ public class ItemCollectionService {
         }
     }
 
-    /**
-     * Wandelt eine ItemCollection-Entity in ein ResponseDTO um.
-     */
     private ItemCollectionResponseDto convertToResponseDto(
             ItemCollection collection) {
 
@@ -353,7 +286,6 @@ public class ItemCollectionService {
             dto.setSubItems(subDtos);
         }
 
-            // Anzahl SubItems hinzufügen
         dto.setSubItemCount(
             collection.getSubItems() != null 
                 ? collection.getSubItems().size() 

--- a/backend/src/main/java/com/datenbank/backend/service/ItemContentService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ItemContentService.java
@@ -46,8 +46,6 @@ public class ItemContentService {
     }
 
 
-    // CRUD
-
     @Transactional(readOnly = true)
     public List<ItemContentResponseDto> getAll() {
         return contentRepository.findAll().stream()
@@ -61,9 +59,6 @@ public class ItemContentService {
         return convertToResponseDto(content);
     }
 
-    /**
-     * Liefert alle Contents eines Items (über item_contents Join-Tabelle).
-     */
     @Transactional(readOnly = true)
     public List<ItemContentResponseDto> getContentsByItemId(UUID itemId) {
         return itemContentsRepository.findByItem_ItemId(itemId)
@@ -76,11 +71,6 @@ public class ItemContentService {
                 })
                 .collect(Collectors.toList());
     }
-    /**
-     * Liefert die Blob-Daten eines Contents direkt als byte[].
-     * Wirft 404 falls Content nicht gefunden.
-     * Wirft 404 falls keine Blob-Daten vorhanden.
-     */
     @Transactional(readOnly = true)
     public byte[] getBlobById(UUID id) {
         ItemContent content = findContentOrThrow(id);
@@ -101,10 +91,7 @@ public class ItemContentService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Erstellt einen neuen Content und verknüpft ihn mit einem Item.
-     * Der Purpose (z. B. "Aufgabenstellung") wird im ItemContents-Join gespeichert.
-     */
+    /** Purpose (z. B. "Aufgabenstellung") wird im item_contents-Join gespeichert. */
     @Transactional
     public ItemContentResponseDto createForItem(UUID itemId, ItemContentCreateDto dto) {
         Item item = itemRepository.findById(itemId)
@@ -133,8 +120,7 @@ public class ItemContentService {
         ItemContent saved = contentRepository.save(content);
 
         // purpose lebt im item_contents-Join: nur aktualisieren wenn mitgeschickt.
-        // In dieser Iteration ist ein Content genau einem Item zugeordnet,
-        // daher werden alle Verknüpfungen dieses Contents gesetzt.
+        // In dieser Iteration ist ein Content genau einem Item zugeordnet.
         if (dto.getPurpose() != null) {
             List<ItemContents> links =
                     itemContentsRepository.findByItemContent_ItemContentId(id);
@@ -145,10 +131,6 @@ public class ItemContentService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Speichert Blob-Daten für einen existierenden Content.
-     * Wirft 404, falls Content nicht gefunden.
-     */
     @Transactional
     public ItemContentResponseDto uploadBlob(UUID id, byte[] blob) {
         ItemContent content = findContentOrThrow(id);
@@ -168,9 +150,6 @@ public class ItemContentService {
 
         contentRepository.deleteById(id);
     }
-
-
-    // Hilfsmethoden
 
 
     private ItemContent findContentOrThrow(UUID id) {
@@ -217,10 +196,7 @@ public class ItemContentService {
         }
     }
 
-    /**
-     * Wandelt eine ItemContent-Entity in ein ResponseDTO um.
-     * Blob-Daten werden NICHT eingebettet — nur ein Flag ob vorhanden.
-     */
+    /** Blob-Daten werden NICHT eingebettet — nur ein Flag ob vorhanden. */
     private ItemContentResponseDto convertToResponseDto(ItemContent content) {
         ItemContentResponseDto dto = new ItemContentResponseDto();
 

--- a/backend/src/main/java/com/datenbank/backend/service/ItemService.java
+++ b/backend/src/main/java/com/datenbank/backend/service/ItemService.java
@@ -25,14 +25,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-/**
- * Service-Schicht für die Geschäftslogik der Item-Entität.
- *
- * Aufgaben:
- *  - Umwandlung zwischen DTOs (Frontend) und Entities (Datenbank)
- *  - Validierung referenzierter Entitäten (Author, License, etc.)
- *  - CRUD-Operationen mit korrekter Fehlerbehandlung
- */
 @Service
 public class ItemService {
 
@@ -47,10 +39,6 @@ public class ItemService {
     private final ItemCollectionRepository collectionRepository;
     private final ItemContentsRepository itemContentsRepository;
 
-    /**
-     * Constructor-Injection: Spring übergibt automatisch die Repositories.
-     * Modern und besser testbar als @Autowired auf Feldern.
-     */
     public ItemService(ItemRepository itemRepository,
                        AuthorRepository authorRepository,
                        LicenseRepository licenseRepository,
@@ -73,13 +61,6 @@ public class ItemService {
         this.itemContentsRepository = itemContentsRepository;
     }
 
-    // =========================================================================
-    // CRUD-Operationen
-    // =========================================================================
-
-    /**
-     * Liefert alle Items als Liste von ResponseDTOs.
-     */
     @Transactional(readOnly = true)
     public List<ItemResponseDto> getAllItems() {
         return itemRepository.findAll().stream()
@@ -87,19 +68,12 @@ public class ItemService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Liefert ein einzelnes Item als ResponseDTO.
-     * Wirft 404, falls nicht gefunden.
-     */
     @Transactional(readOnly = true)
     public ItemResponseDto getItemById(UUID id) {
         Item item = findItemOrThrow(id);
         return convertToResponseDto(item);
     }
 
-    /**
-     * Erstellt ein neues Item aus einem CreateDTO.
-     */
     @Transactional
     public ItemResponseDto createItem(ItemCreateDto dto) {
         Item item = new Item();
@@ -108,10 +82,6 @@ public class ItemService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Aktualisiert ein existierendes Item.
-     * Wirft 404, falls das Item nicht existiert.
-     */
     @Transactional
     public ItemResponseDto updateItem(UUID id, ItemCreateDto dto) {
         Item item = findItemOrThrow(id);
@@ -120,10 +90,6 @@ public class ItemService {
         return convertToResponseDto(saved);
     }
 
-    /**
-     * Löscht ein Item.
-     * Wirft 404, falls das Item nicht existiert.
-     */
     @Transactional
     public void deleteItem(UUID id) {
         if (!itemRepository.existsById(id)) {
@@ -133,7 +99,7 @@ public class ItemService {
     }
 
     /**
-     * Hängt ein vorhandenes Tag an ein Item (item_tags). Idempotent, da Set.
+     * Idempotent, da Set.
      */
     @Transactional
     public ItemResponseDto addTag(UUID itemId, UUID tagId) {
@@ -144,9 +110,6 @@ public class ItemService {
         return convertToResponseDto(itemRepository.save(item));
     }
 
-    /**
-     * Entfernt ein Tag von einem Item (nur die Verknüpfung, das Tag bleibt).
-     */
     @Transactional
     public ItemResponseDto removeTag(UUID itemId, UUID tagId) {
         Item item = findItemOrThrow(itemId);
@@ -154,9 +117,6 @@ public class ItemService {
         return convertToResponseDto(itemRepository.save(item));
     }
 
-    /**
-    * Liefert nur Root-Items (root_item_id IS NULL)
-    */
     @Transactional(readOnly = true)
     public List<ItemResponseDto> getRootItems() {
         return itemRepository.findByRootItemIsNull().stream()
@@ -164,9 +124,6 @@ public class ItemService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Liefert alle Kinder eines Items
-     */
     @Transactional(readOnly = true)
     public List<ItemResponseDto> getItemsByRootId(UUID rootItemId) {
         return itemRepository.findByRootItem_ItemId(rootItemId).stream()
@@ -224,10 +181,6 @@ public class ItemService {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Konvertiert ein Item in eine Collection.
-     * Erstellt eine ItemCollection, die auf dieses Item verweist.
-     */
     @Transactional
     public ItemResponseDto convertToCollection(UUID itemId) {
         Item item = findItemOrThrow(itemId);
@@ -239,10 +192,6 @@ public class ItemService {
 
         return convertToResponseDto(item);
     }
-
-    // =========================================================================
-    // Validator-Verknüpfungen
-    // =========================================================================
 
     @Transactional(readOnly = true)
     public List<ValidatorResponseDto> getValidatorsForItem(UUID itemId) {
@@ -281,25 +230,14 @@ public class ItemService {
         return convertToResponseDto(saved);
     }
 
-    // =========================================================================
-    // Hilfsmethoden
-    // =========================================================================
-
-    /**
-     * Holt ein Item aus der DB oder wirft 404.
-     */
     private Item findItemOrThrow(UUID id) {
         return itemRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "Item nicht gefunden"));
     }
 
-    /**
-     * Wendet die Daten eines CreateDTO auf eine Item-Entity an.
-     * Wird sowohl bei Create als auch bei Update verwendet.
-     */
     private void applyDtoToEntity(ItemCreateDto dto, Item item) {
-        // Pflicht-Beziehungen (NOT NULL)
+        // NOT NULL
         item.setAuthor(authorRepository.findById(dto.getAuthorId())
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "Author nicht gefunden")));
@@ -368,33 +306,26 @@ public class ItemService {
         }
     }
 
-    /**
-     * Wandelt eine Item-Entity in ein ResponseDTO um.
-     */
     private ItemResponseDto convertToResponseDto(Item item) {
         ItemResponseDto dto = new ItemResponseDto();
 
         dto.setItemId(item.getItemId());
 
-        // Author
         if (item.getAuthor() != null) {
             dto.setAuthorId(item.getAuthor().getAuthorId());
             dto.setAuthorDescriptor(item.getAuthor().getDescriptor());
         }
 
-        // License
         if (item.getLicense() != null) {
             dto.setLicenseId(item.getLicense().getLicenseId());
             dto.setLicenseName(item.getLicense().getLicense());
         }
 
-        // ItemType
         if (item.getItemType() != null) {
             dto.setItemTypeId(item.getItemType().getItemTypeId());
             dto.setItemTypeName(item.getItemType().getItemTypeName());
         }
 
-        // Optionale Beziehungen
         if (item.getItemTemplate() != null) {
             dto.setItemTemplateId(item.getItemTemplate().getItemTemplateId());
         }
@@ -403,7 +334,6 @@ public class ItemService {
             dto.setRootItemId(item.getRootItem().getItemId());
         }
 
-        // Many-to-Many als IDs
         dto.setTagIds(item.getTags().stream()
                 .map(Tag::getTagId)
                 .collect(Collectors.toSet()));
@@ -416,7 +346,6 @@ public class ItemService {
                 .map(Modifier::getModifierId)
                 .collect(Collectors.toSet()));
 
-        // Timestamps
         dto.setCreatedAt(item.getCreatedAt());
         dto.setUpdatedAt(item.getUpdatedAt());
 

--- a/backend/src/test/java/com/datenbank/backend/service/ItemCollectionServiceTest.java
+++ b/backend/src/test/java/com/datenbank/backend/service/ItemCollectionServiceTest.java
@@ -78,8 +78,6 @@ class ItemCollectionServiceTest {
         collection.setSubItems(subItems);
     }
 
-    // ── toggleOrder ──
-
     @Test
     void toggleOrder_true_assignsSequentialPositions() {
         when(collectionRepository.findById(COLLECTION_ID)).thenReturn(Optional.of(collection));
@@ -124,8 +122,6 @@ class ItemCollectionServiceTest {
                 () -> service.toggleOrder(NOT_FOUND_ID, true));
     }
 
-    // ── updateSubItemPosition ──
-
     @Test
     void updateSubItemPosition_movesFirstToThird() {
         sub1.setPosition(1);
@@ -167,8 +163,6 @@ class ItemCollectionServiceTest {
         assertThrows(ResponseStatusException.class,
                 () -> service.updateSubItemPosition(COLLECTION_ID, NOT_FOUND_ID, 1));
     }
-
-    // ── removeItemFromCollection ──
 
     @Test
     void removeItemFromCollection_removesMiddleAndRecalculates() {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,11 +24,14 @@ import BreadCrumb from '@/components/BreadCrumb.vue'
 import FooterMain from '@/components/layout/FooterMain.vue'
 import HeaderMain from '@/components/layout/HeaderMain.vue'
 import NotificationToast from '@/components/NotificationToast.vue'
+import { useThemeStore } from '@/stores/themeStore'
 
 const router = useRouter()
 
 const hideBreadcrumbIn = ['Home', 'ViewLogin', 'ViewIntroduction', 'View404Page']
 const showBreadcrumb = ref(true)
+
+const themeStore = useThemeStore()
 
 watch(
   () => router.currentRoute.value.name,
@@ -43,5 +46,11 @@ watch(
   }
 )
 
-onMounted(() => {})
+onMounted(() => {
+  themeStore.init()
+})
 </script>
+
+<style>
+@import '@/styles/theme.css';
+</style>

--- a/frontend/src/components/layout/HeaderMain.vue
+++ b/frontend/src/components/layout/HeaderMain.vue
@@ -11,6 +11,16 @@
     </v-toolbar-title>
     <v-spacer />
     <v-btn
+      variant="text"
+      icon
+      @click="themeStore.toggle()"
+    >
+      <v-icon>{{ themeStore.isDark() ? 'mdi-white-balance-sunny' : 'mdi-moon-waning-crescent' }}</v-icon>
+      <v-tooltip activator="parent" location="bottom">
+        {{ themeStore.isDark() ? 'Helles Design' : 'Dunkles Design' }}
+      </v-tooltip>
+    </v-btn>
+    <v-btn
       v-if="isLoggedIn"
       to="/profile"
       variant="text"
@@ -134,6 +144,18 @@
         </v-tooltip>
       </v-btn>
       <v-btn
+        icon
+        @click="themeStore.toggle()"
+      >
+        <v-icon>{{ themeStore.isDark() ? 'mdi-white-balance-sunny' : 'mdi-moon-waning-crescent' }}</v-icon>
+        <v-tooltip
+          activator="parent"
+          location="bottom"
+        >
+          {{ themeStore.isDark() ? 'Helles Design' : 'Dunkles Design' }}
+        </v-tooltip>
+      </v-btn>
+      <v-btn
         v-if="isLoggedIn"
         icon
         @click="pageSettingsStore.showHeader = !pageSettingsStore.showHeader"
@@ -168,6 +190,7 @@ import IconFBS from '@/components/icons/IconFBS.vue'
 
 import { usePageSettingsStore } from '@/stores/pageSettingsStore'
 import { useAuthUserStore } from '@/stores/authUserStore'
+import { useThemeStore } from '@/stores/themeStore'
 
 import { RouterLink } from 'vue-router'
 import { computed, ref } from 'vue'
@@ -182,6 +205,7 @@ const authUserStore = useAuthUserStore()
 const isLoggedIn = computed(() => authUserStore.isLoggedIn)
 
 const pageSettingsStore = usePageSettingsStore()
+const themeStore = useThemeStore()
 
 const logout = () => {
   authUserStore.logout().then(() => {

--- a/frontend/src/feature/aufgabendatenbank/Adb.vue
+++ b/frontend/src/feature/aufgabendatenbank/Adb.vue
@@ -49,7 +49,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background-color: #1e1e1e;
+  background-color: var(--adb-bg-primary);
 }
 
 .adb-content {
@@ -85,7 +85,7 @@ onMounted(() => {
   }
 
   &:hover::after, &:active::after {
-    background-color: #007fd4;
+    background-color: var(--adb-accent);
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/adbApi.service.ts
@@ -184,7 +184,7 @@ export class AdbApiService implements ApiAdapter {
     return data
   }
 
-  // ── Validators ───────────────────────────────────────────────────────
+  // Validators
 
   async getValidators(): Promise<ValidatorDTO[]> {
     const { data } = await this.http.get<ValidatorDTO[]>('/validators')

--- a/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
+++ b/frontend/src/feature/aufgabendatenbank/api-adapter.types.ts
@@ -52,7 +52,7 @@ export interface ContentSummaryDTO {
   hasBlobContent: boolean
 }
 
-// ── Referenzdaten (Lookup-Listen für Dropdowns) ──────────────────────────────
+// Referenzdaten (Lookup-Listen für Dropdowns)
 
 export interface AuthorDTO {
   id: string
@@ -196,13 +196,13 @@ export interface ApiAdapter {
 
   getItemsByRootId(rootItemId: string): Promise<ItemDTO[]>
 
-  // ── Representation Templates ───────────────────────────────────────────
+  // Representation Templates
 
   getRepresentationTemplates(): Promise<ReprTemplateDTO[]>
   createRepresentationTemplate(payload: { template: string }): Promise<ReprTemplateDTO>
   updateRepresentationTemplate(id: string, payload: { template: string }): Promise<ReprTemplateDTO>
 
-  // ── Validators ───────────────────────────────────────────────────────
+  // Validators
 
   getValidators(): Promise<ValidatorDTO[]>
 

--- a/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
+++ b/frontend/src/feature/aufgabendatenbank/dev-adb-api.service.ts
@@ -466,7 +466,7 @@ export class DevAdbApiService implements ApiAdapter {
     return dummyData.rootItems.map(toDTO)
   }
 
-  // ── Referenzdaten (gleiche Seeds wie database/init/init.sql) ───────────────
+  // Referenzdaten (gleiche Seeds wie database/init/init.sql)
 
   async getAuthors(): Promise<AuthorDTO[]> {
     log('GET', '/api/authors')
@@ -537,7 +537,7 @@ export class DevAdbApiService implements ApiAdapter {
       .map(ci => toDTO(ci.item))
   }
 
-  // ── Representation Templates ─────────────────────────────────────────
+  // Representation Templates
 
   private _templates: ReprTemplateDTO[] = [...seedTemplates]
 
@@ -561,7 +561,7 @@ export class DevAdbApiService implements ApiAdapter {
     return { ...this._templates[idx] }
   }
 
-  // ── Validators ───────────────────────────────────────────────────────
+  // Validators
 
   private _validators: ValidatorDTO[] = [...seedValidators]
 

--- a/frontend/src/feature/aufgabendatenbank/dummy-data.ts
+++ b/frontend/src/feature/aufgabendatenbank/dummy-data.ts
@@ -14,7 +14,7 @@ import type { Item } from '@/lib/types'
  */
 export const dummyData: { rootItems: Item[] } = {
   rootItems: [
-    // ── 1. Unordered collection ────────────────────────────────────────────
+    // 1. Unordered collection
     {
       id: 'coll-sql-basics',
       item_type: 'collection',
@@ -126,7 +126,7 @@ export const dummyData: { rootItems: Item[] } = {
       order: false
     },
 
-    // ── 2. Ordered collection (progressive difficulty) ─────────────────────
+    // 2. Ordered collection (progressive difficulty)
     {
       id: 'coll-sql-advanced',
       item_type: 'collection',
@@ -266,7 +266,7 @@ export const dummyData: { rootItems: Item[] } = {
       order: true
     },
 
-    // ── 3. Nested sub-collections ───────────────────────────────────────────
+    // 3. Nested sub-collections
     {
       id: 'coll-db-design',
       item_type: 'collection',
@@ -498,7 +498,7 @@ export const dummyData: { rootItems: Item[] } = {
       order: false
     },
 
-    // ── 4. Standalone root-level exercises ─────────────────────────────────
+    // 4. Standalone root-level exercises
     {
       id: 'item-sql-indexes',
       item_type: 'exercise',

--- a/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/AdbEditor.vue
@@ -137,8 +137,8 @@ watch(editedXml, (xml) => {
   width: 100%;
   border-radius: 0;
   box-shadow: none !important;
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
 }
 
 .adb-editor-title {
@@ -146,17 +146,17 @@ watch(editedXml, (xml) => {
   font-size: 0.75rem;
   line-height: 16px;
   text-transform: uppercase;
-  color: #969696;
-  border-bottom: 1px solid #333333;
+  color: var(--adb-text-secondary);
+  border-bottom: 1px solid var(--adb-border);
   padding: 8px 16px !important;
-  background-color: #252526;
+  background-color: var(--adb-bg-secondary);
   user-select: none;
 }
 
 .adb-editor-text {
   padding: 28px 36px;
   font-size: 13px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   overflow-y: auto;
   max-height: 100%;
 }
@@ -167,12 +167,12 @@ watch(editedXml, (xml) => {
 
 :deep(.v-text-field) {
   .v-field {
-    background-color: #3c3c3c !important;
-    color: #cccccc !important;
+    background-color: var(--adb-bg-field) !important;
+    color: var(--adb-text-primary) !important;
     border-radius: 2px;
   }
   .v-label {
-    color: #969696 !important;
+    color: var(--adb-text-secondary) !important;
   }
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentEditor.vue
@@ -266,8 +266,8 @@ function onImgError() {
 
 <style scoped lang="scss">
 .content-card {
-  background: #2d2d2d;
-  border: 1px solid #3c3c3c;
+  background: var(--adb-bg-surface);
+  border: 1px solid var(--adb-border);
   border-radius: 24px;
   padding: 12px 16px;
   margin-bottom: 10px;
@@ -299,7 +299,7 @@ function onImgError() {
 
 .purpose-badge {
   display: inline-block;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -317,7 +317,7 @@ function onImgError() {
   left: 12px;
   font-size: 8px;
   line-height: 1;
-  color: #555;
+  color: var(--adb-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   pointer-events: none;
@@ -332,17 +332,17 @@ function onImgError() {
   display: block;
   width: 100%;
   padding: 11px 8px 2px 12px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.01em;
-  border-bottom: 1px solid #007fd4;
+  border-bottom: 1px solid var(--adb-accent);
   outline: none;
   box-sizing: border-box;
 }
 
 .edit-hint {
-  color: #555;
+  color: var(--adb-text-muted);
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 0.15s;
@@ -364,12 +364,12 @@ function onImgError() {
 .card-divider {
   height: 0;
   border: none;
-  border-bottom: 1px solid #3c3c3c;
+  border-bottom: 1px solid var(--adb-border);
   margin: 6px -16px 8px;
 }
 
 .delete-btn {
-  color: #666 !important;
+  color: var(--adb-icon) !important;
   opacity: 0.7;
   transition:
     opacity 0.15s,
@@ -378,7 +378,7 @@ function onImgError() {
 
   &:hover {
     opacity: 1;
-    color: #ff7a84 !important;
+    color: var(--adb-danger) !important;
   }
 }
 
@@ -404,7 +404,7 @@ function onImgError() {
   gap: 6px;
   font-size: 15px;
   line-height: 1.6;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   cursor: pointer;
   padding: 8px 10px;
   margin: 0 -10px;
@@ -430,9 +430,9 @@ function onImgError() {
   box-sizing: border-box;
   font-size: 15px;
   line-height: 1.6;
-  color: #cccccc;
-  background: #1e1e1e;
-  border: 1px solid #007fd4;
+  color: var(--adb-text-primary);
+  background: var(--adb-bg-primary);
+  border: 1px solid var(--adb-accent);
   border-radius: 8px;
   padding: 14px 12px 6px 12px;
   resize: vertical;
@@ -440,7 +440,7 @@ function onImgError() {
   font-family: inherit;
 
   &::placeholder {
-    color: #666;
+    color: var(--adb-text-muted);
   }
 }
 
@@ -456,7 +456,7 @@ function onImgError() {
   align-items: flex-start;
   gap: 8px;
   padding: 8px 10px;
-  background: #1e1e1e;
+  background: var(--adb-bg-primary);
   border-radius: 12px;
 }
 
@@ -476,7 +476,7 @@ function onImgError() {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: #007fd4;
+  color: var(--adb-accent);
   text-decoration: none;
   font-size: 13px;
   padding: 4px 10px;
@@ -493,13 +493,13 @@ function onImgError() {
   align-items: center;
   gap: 10px;
   padding: 8px 10px;
-  background: #1e1e1e;
+  background: var(--adb-bg-primary);
   border-radius: 12px;
 }
 
 .blob-filename {
   font-size: 13px;
-  color: #ccc;
+  color: var(--adb-text-primary);
   flex: 1;
 }
 
@@ -516,17 +516,17 @@ function onImgError() {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   font-size: 13px;
   cursor: pointer;
   padding: 6px 12px;
   border-radius: 12px;
-  border: 1px dashed #555;
+  border: 1px dashed var(--adb-border-light);
   transition: all 0.15s;
 
   &:hover {
-    color: #ccc;
-    border-color: #888;
+    color: var(--adb-text-primary);
+    border-color: var(--adb-text-tertiary);
     background: rgba(255, 255, 255, 0.03);
   }
 }

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbContentList.vue
@@ -100,7 +100,7 @@ function realIndex(content: Content): number {
   min-height: 48px;
   padding: 0 16px;
   border-radius: 24px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   font-size: 13px;
   cursor: pointer;
   transition:
@@ -118,7 +118,7 @@ function realIndex(content: Content): number {
   }
 
   &:hover {
-    color: #cccccc;
+    color: var(--adb-text-primary);
   }
 
   &:hover::before {
@@ -146,34 +146,34 @@ function realIndex(content: Content): number {
   transition: background-color 0.15s;
 
   background-color: transparent;
-  border: 1px solid #444;
+  border: 1px solid var(--adb-border);
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.03);
   }
 
   &.active {
-    background-color: #252526;
-    border-color: #007fd4;
+    background-color: var(--adb-bg-secondary);
+    border-color: var(--adb-accent);
   }
 }
 
 .order-icon {
-  color: #666;
+  color: var(--adb-icon);
   transition: color 0.15s;
 
   &.active {
-    color: #007fd4;
+    color: var(--adb-accent);
   }
 }
 
 .order-text {
   font-size: 13px;
-  color: #aaa;
+  color: var(--adb-text-tertiary);
   transition: color 0.15s;
 
   .order-card.active & {
-    color: #ccc;
+    color: var(--adb-text-primary);
   }
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbDeleteDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbDeleteDialog.vue
@@ -68,21 +68,21 @@ function onCancel() {
 
 <style scoped lang="scss">
 .delete-dialog-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
-  border: 1px solid #333;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
+  border: 1px solid var(--adb-border);
 }
 
 .delete-dialog-title {
   font-size: 16px;
   font-weight: 600;
-  color: #e0e0e0;
+  color: var(--adb-text-primary);
   padding: 20px 24px 8px;
 }
 
 .delete-dialog-text {
   font-size: 13px;
-  color: #999;
+  color: var(--adb-text-tertiary);
   padding: 8px 24px 16px;
   line-height: 1.5;
 }
@@ -92,23 +92,23 @@ function onCancel() {
 }
 
 .cancel-btn {
-  color: #999 !important;
+  color: var(--adb-text-tertiary) !important;
   text-transform: none;
   font-weight: 500;
 
   &:hover {
-    color: #ccc !important;
+    color: var(--adb-text-primary) !important;
   }
 }
 
 .confirm-btn {
-  background-color: #c04040 !important;
-  color: #fff !important;
+  background-color: var(--adb-danger) !important;
+  color: var(--adb-text-inverse) !important;
   text-transform: none;
   font-weight: 600;
 
   &:hover {
-    background-color: #e06060 !important;
+    background-color: var(--adb-danger-hover) !important;
   }
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbTagCheckNode.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbTagCheckNode.vue
@@ -64,13 +64,13 @@ const checked = computed(() => props.assigned.includes(props.node.id))
 }
 
 .chevron {
-  color: #888;
+  color: var(--adb-text-tertiary);
   cursor: pointer;
   width: 18px;
   min-width: 18px;
 
   &:hover {
-    color: #ccc;
+    color: var(--adb-text-primary);
   }
 }
 
@@ -91,19 +91,19 @@ const checked = computed(() => props.assigned.includes(props.node.id))
   user-select: none;
 
   &:hover {
-    background-color: #2a2d2e;
+    background-color: var(--adb-bg-hover);
   }
 }
 
 .checkbox {
-  color: #7a7a7a;
+  color: var(--adb-text-tertiary);
 
   &.checked {
-    color: #007fd4;
+    color: var(--adb-accent);
   }
 }
 
 .tag-check-name {
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbTagsSection.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbTagsSection.vue
@@ -160,7 +160,7 @@ async function confirm() {
 
 .tags-label {
   font-size: 0.75rem;
-  color: #969696;
+  color: var(--adb-text-secondary);
 }
 
 .tags-chips {
@@ -171,18 +171,18 @@ async function confirm() {
 }
 
 .tags-empty {
-  color: #6a6a6a;
+  color: var(--adb-text-tertiary);
   font-size: 0.85rem;
 }
 
 .tags-tree {
   max-height: 220px;
   overflow-y: auto;
-  border: 1px solid #3a3a3a;
+  border: 1px solid var(--adb-border);
   border-radius: 4px;
   padding: 4px 2px;
   margin-bottom: 10px;
-  background-color: #232323;
+  background-color: var(--adb-bg-chip);
 }
 
 .tags-actions {
@@ -196,21 +196,21 @@ async function confirm() {
 }
 
 .tag-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
 }
 
 .tag-title {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 15px;
   font-weight: 600;
 }
 
 .cancel-btn {
-  color: #969696 !important;
+  color: var(--adb-text-secondary) !important;
 }
 
 .confirm-btn {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbValidatorEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbValidatorEditor.vue
@@ -140,7 +140,7 @@ function cancelCreate() {
 .validator-section {
   margin-top: 24px;
   padding-top: 20px;
-  border-top: 1px solid #333;
+  border-top: 1px solid var(--adb-border);
 }
 
 .section-header {
@@ -153,13 +153,13 @@ function cancelCreate() {
 .section-title {
   font-size: 13px;
   font-weight: 600;
-  color: #969696;
+  color: var(--adb-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .add-btn {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 
 .validators-list {
@@ -173,8 +173,8 @@ function cancelCreate() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: #2a2a2a;
-  border: 1px solid #444;
+  background-color: var(--adb-bg-chip);
+  border: 1px solid var(--adb-border);
   border-radius: 4px;
   padding: 8px 10px;
   gap: 8px;
@@ -189,24 +189,24 @@ function cancelCreate() {
 
 .validator-desc {
   font-size: 13px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-weight: 500;
 }
 
 .validator-rule {
   font-size: 11px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   font-family: monospace;
 }
 
 .remove-btn {
-  color: #c04040 !important;
+  color: var(--adb-danger) !important;
   flex-shrink: 0;
 }
 
 .empty-hint {
   font-size: 12px;
-  color: #666;
+  color: var(--adb-text-muted);
   font-style: italic;
   padding: 4px 0;
 }
@@ -217,7 +217,7 @@ function cancelCreate() {
 
 .available-label {
   font-size: 11px;
-  color: #777;
+  color: var(--adb-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
   display: block;
@@ -232,9 +232,9 @@ function cancelCreate() {
 
 .available-chip {
   font-size: 12px;
-  color: #aaa;
-  background-color: #252525;
-  border: 1px dashed #555;
+  color: var(--adb-text-tertiary);
+  background-color: var(--adb-bg-chip);
+  border: 1px dashed var(--adb-border-light);
   border-radius: 4px;
   padding: 4px 10px;
   cursor: pointer;
@@ -242,18 +242,18 @@ function cancelCreate() {
 }
 
 .available-chip:hover {
-  color: #007fd4;
-  border-color: #007fd4;
-  background-color: #0d2b45;
+  color: var(--adb-accent);
+  border-color: var(--adb-accent);
+  background-color: var(--adb-bg-active);
 }
 
 .dialog-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
 }
 
 .dialog-title {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 16px;
   font-weight: 600;
 }
@@ -267,10 +267,10 @@ function cancelCreate() {
 }
 
 .cancel-btn {
-  color: #969696 !important;
+  color: var(--adb-text-secondary) !important;
 }
 
 .save-btn {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbVariantsPanel.vue
@@ -85,7 +85,7 @@ function onAddVariant() {
 .variants-panel {
   margin-top: 32px;
   padding-top: 24px;
-  border-top: 1px solid #333;
+  border-top: 1px solid var(--adb-border);
 }
 
 .variants-header {
@@ -98,14 +98,14 @@ function onAddVariant() {
 .variants-title {
   font-size: 15px;
   font-weight: 600;
-  color: #ccc;
+    color: var(--adb-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
 .variants-count {
-  background: #3c3c3c;
-  color: #999;
+  background: var(--adb-bg-field);
+  color: var(--adb-text-tertiary);
   font-size: 11px;
   font-weight: 600;
   padding: 1px 8px;
@@ -120,8 +120,8 @@ function onAddVariant() {
 }
 
 .variant-card {
-  background: #252526;
-  border: 1px solid #3c3c3c;
+  background: var(--adb-bg-secondary);
+  border: 1px solid var(--adb-border);
   border-radius: 16px;
   padding: 12px;
 }
@@ -132,18 +132,18 @@ function onAddVariant() {
   justify-content: space-between;
   margin-bottom: 10px;
   padding-bottom: 8px;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--adb-border);
 }
 
 .variant-label {
   font-size: 13px;
   font-weight: 600;
-  color: #aaa;
+    color: var(--adb-text-tertiary);
 }
 
 .variant-id {
   font-size: 10px;
-  color: #555;
+  color: var(--adb-text-muted);
   font-family: monospace;
 }
 
@@ -162,16 +162,16 @@ function onAddVariant() {
   min-height: 36px;
   padding: 0 12px;
   border-radius: 16px;
-  color: #666;
+  color: var(--adb-text-muted);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s;
-  border: 1px dashed #444;
+  border: 1px dashed var(--adb-border);
   margin-top: 4px;
 
   &:hover {
-    color: #aaa;
-    border-color: #666;
+  color: var(--adb-text-tertiary);
+    border-color: var(--adb-icon);
     background: rgba(255, 255, 255, 0.02);
   }
 }
@@ -183,15 +183,15 @@ function onAddVariant() {
   min-height: 44px;
   padding: 0 16px;
   border-radius: 22px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   font-size: 13px;
   cursor: pointer;
   transition: all 0.15s;
-  border: 1px dashed #555;
+  border: 1px dashed var(--adb-border-light);
 
   &:hover {
-    color: #ccc;
-    border-color: #888;
+  color: var(--adb-text-primary);
+    border-color: var(--adb-text-tertiary);
     background: rgba(255, 255, 255, 0.02);
   }
 }

--- a/frontend/src/feature/aufgabendatenbank/editor/components/AdbXmlEditor.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/AdbXmlEditor.vue
@@ -40,14 +40,14 @@ function onChange(value: string) {
 }
 
 .xml-codemirror {
-  border: 1px solid #3c3c3c;
+  border: 1px solid var(--adb-border);
   border-radius: 8px;
   overflow: hidden;
   transition: border-color 0.15s;
 }
 
 .xml-codemirior:focus-within {
-  border-color: #007fd4;
+  border-color: var(--adb-accent);
 }
 
 .xml-codemirror {

--- a/frontend/src/feature/aufgabendatenbank/editor/components/EditorMetadataBar.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/EditorMetadataBar.vue
@@ -141,7 +141,7 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
 
 .order-hint {
   font-size: 11px;
-  color: #777;
+  color: var(--adb-text-tertiary);
   user-select: none;
   white-space: nowrap;
 }
@@ -153,8 +153,8 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
   line-height: 0;
 
   &.visible {
-    background-color: #0d2b45;
-    box-shadow: 0 0 0 1px #007fd4;
+    background-color: var(--adb-bg-active);
+    box-shadow: 0 0 0 1px var(--adb-accent);
   }
 }
 
@@ -162,8 +162,8 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
   border-radius: 4px;
   padding: 0 14px;
   line-height: 0;
-  background-color: #4a1a1a;
-  box-shadow: 0 0 0 1px #c04040;
+  background-color: var(--adb-bg-active);
+  box-shadow: 0 0 0 1px var(--adb-danger);
   display: flex;
   align-items: center;
   height: 32px;
@@ -171,7 +171,7 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
 }
 
 .delete-btn {
-  color: #c04040 !important;
+  color: var(--adb-danger) !important;
   font-size: 13px;
   font-weight: 600;
   text-transform: none;
@@ -193,12 +193,12 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
   }
 
   &:hover {
-    color: #e06060 !important;
+    color: var(--adb-danger-hover) !important;
   }
 }
 
 .order-btn {
-  color: #666 !important;
+  color: var(--adb-icon) !important;
   transition: color 0.15s;
   margin: 0 !important;
   padding: 1rem !important;
@@ -220,14 +220,14 @@ function onMeta(meta: { authorId?: string; licenseId?: string; itemTypeId?: stri
   }
 
   &:hover {
-    color: #999 !important;
+    color: var(--adb-text-tertiary) !important;
   }
 
   &.active {
-    color: #007fd4 !important;
+    color: var(--adb-accent) !important;
 
     &:hover {
-      color: #1a9aff !important;
+      color: var(--adb-accent-hover) !important;
     }
   }
 }

--- a/frontend/src/feature/aufgabendatenbank/editor/components/PreviewDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/PreviewDialog.vue
@@ -166,8 +166,8 @@ const previewGroups = computed(() => {
 
 <style scoped lang="scss">
 .preview-dialog {
-  background-color: #2d2d2d !important;
-  color: #d4d4d4;
+  background-color: var(--adb-bg-dialog) !important;
+  color: var(--adb-text-primary);
   border-radius: 16px !important;
 }
 
@@ -178,13 +178,13 @@ const previewGroups = computed(() => {
   font-size: 15px;
   font-weight: 500;
   padding: 14px 20px !important;
-  background: #252526;
-  border-bottom: 1px solid #3c3c3c;
+  background: var(--adb-bg-secondary);
+  border-bottom: 1px solid var(--adb-border);
   flex-shrink: 0;
 }
 
 .preview-title-icon {
-  color: #007fd4;
+  color: var(--adb-accent);
 }
 
 .preview-body {
@@ -209,7 +209,7 @@ const previewGroups = computed(() => {
 .preview-block-purpose {
   font-size: 10px;
   font-weight: 600;
-  color: #969696;
+  color: var(--adb-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 6px;
@@ -220,7 +220,7 @@ const previewGroups = computed(() => {
   line-height: 1.7;
   white-space: pre-wrap;
   word-break: break-word;
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 
 .preview-img {
@@ -235,7 +235,7 @@ const previewGroups = computed(() => {
   align-items: center;
   gap: 10px;
   padding: 12px 16px;
-  background: #1e1e1e;
+  background: var(--adb-bg-primary);
   border-radius: 12px;
 }
 
@@ -243,7 +243,7 @@ const previewGroups = computed(() => {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: #007fd4;
+  color: var(--adb-accent);
   text-decoration: none;
   font-size: 13px;
   padding: 4px 10px;
@@ -256,7 +256,7 @@ const previewGroups = computed(() => {
 }
 
 .preview-empty {
-  color: #999;
+  color: var(--adb-text-tertiary);
   text-align: center;
   padding: 60px 0;
 }

--- a/frontend/src/feature/aufgabendatenbank/editor/components/TemplateEditorPanel.vue
+++ b/frontend/src/feature/aufgabendatenbank/editor/components/TemplateEditorPanel.vue
@@ -296,7 +296,7 @@ function isHighlighted(element: DndItem): boolean {
 .template-editor-label {
   font-size: 11px;
   text-transform: uppercase;
-  color: #969696;
+  color: var(--adb-text-secondary);
   letter-spacing: 0.08em;
   user-select: none;
 }
@@ -309,12 +309,12 @@ function isHighlighted(element: DndItem): boolean {
 }
 
 .template-validation.valid {
-  color: #4caf50;
+  color: var(--adb-success);
   background: rgba(76, 175, 80, 0.1);
 }
 
 .template-validation.invalid {
-  color: #ff7a84;
+  color: var(--adb-danger);
   background: rgba(255, 122, 132, 0.1);
 }
 
@@ -327,8 +327,8 @@ function isHighlighted(element: DndItem): boolean {
 .purpose-card {
   cursor: grab;
   user-select: none;
-  background: #2a2a2a;
-  border: 1px solid #3c3c3c;
+  background: var(--adb-bg-chip);
+  border: 1px solid var(--adb-border);
   border-radius: 6px;
   transition: border-color 0.15s, background 0.15s;
 }
@@ -338,30 +338,30 @@ function isHighlighted(element: DndItem): boolean {
 }
 
 .purpose-card:hover {
-  background: #303030;
-  border-color: #555;
+  background: var(--adb-bg-hover);
+  border-color: var(--adb-border-light);
 }
 
 .purpose-card.split {
-  border-left: 3px solid #0d6efd;
-  background: #262a30;
+  border-left: 3px solid var(--adb-accent);
+  background: var(--adb-bg-surface);
 }
 
 .purpose-card.split:hover {
-  background: #2b3038;
+  background: var(--adb-bg-hover);
 }
 
 .purpose-card.highlighted {
-  border-color: #ffc107;
+  border-color: var(--adb-warning);
   box-shadow: 0 0 0 2px rgba(255, 193, 7, 0.35);
 }
 
 .purpose-card.highlighted.split {
-  border-left-color: #ffc107;
+  border-left-color: var(--adb-warning);
 }
 
 .purpose-card.drag-active .drop-zone {
-  border-color: #0d6efd;
+  border-color: var(--adb-accent);
   background: rgba(13, 110, 253, 0.08);
 }
 
@@ -388,7 +388,7 @@ function isHighlighted(element: DndItem): boolean {
 .split-gap {
   width: 1px;
   align-self: stretch;
-  background: #3c3c3c;
+  background: var(--adb-border);
   flex-shrink: 0;
 }
 
@@ -401,13 +401,13 @@ function isHighlighted(element: DndItem): boolean {
 }
 
 .drop-zone:hover {
-  border-color: #0d6efd;
+  border-color: var(--adb-accent);
   background: rgba(13, 110, 253, 0.06);
 }
 
 .drop-label {
   font-size: 11px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -417,7 +417,7 @@ function isHighlighted(element: DndItem): boolean {
 .card-name {
   flex: 1;
   font-size: 13px;
-  color: #d4d4d4;
+  color: var(--adb-text-primary);
   font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
   min-width: 0;
   overflow: hidden;
@@ -426,7 +426,7 @@ function isHighlighted(element: DndItem): boolean {
 }
 
 .card-menu {
-  color: #555 !important;
+  color: var(--adb-text-muted) !important;
   opacity: 0;
   transition: opacity 0.15s, color 0.15s;
   flex-shrink: 0;
@@ -437,36 +437,36 @@ function isHighlighted(element: DndItem): boolean {
 }
 
 .card-menu:hover {
-  color: #999 !important;
+  color: var(--adb-text-tertiary) !important;
 }
 
 .purpose-ghost {
   opacity: 0.3;
-  border: 2px dashed #007fd4;
+  border: 2px dashed var(--adb-accent);
   background: rgba(0, 127, 212, 0.08);
   border-radius: 6px;
 }
 
 .template-edit-btn {
-  color: #666 !important;
+  color: var(--adb-icon) !important;
   transition: color 0.15s;
   margin-left: auto !important;
 }
 
 .template-edit-btn:hover {
-  color: #999 !important;
+  color: var(--adb-text-tertiary) !important;
 }
 
 .template-edit-btn.active {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 
 .template-preview-btn {
-  color: #666 !important;
+  color: var(--adb-icon) !important;
   transition: color 0.15s;
 }
 
 .template-preview-btn:hover {
-  color: #999 !important;
+  color: var(--adb-text-tertiary) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/structure/AdbStructure.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/AdbStructure.vue
@@ -123,21 +123,21 @@ const updateRootItems = (newItems: typeof store.rootItems) => {
 .adb-structure-container {
   height: 100%;
   width: 100%;
-  background-color: #252526;
+  background-color: var(--adb-bg-secondary);
   display: flex;
   flex-direction: column;
-  border-right: 1px solid #333333;
-  color: #cccccc;
+  border-right: 1px solid var(--adb-border);
+  color: var(--adb-text-primary);
 }
 
 .adb-structure-header {
   padding: 8px 16px;
   font-size: 0.75rem;
   line-height: 16px;
-  color: #969696;
+  color: var(--adb-text-secondary);
   user-select: none;
-  background-color: #252526;
-  border-bottom: 1px solid #333333;
+  background-color: var(--adb-bg-secondary);
+  border-bottom: 1px solid var(--adb-border);
 }
 
 .tag-filter {
@@ -165,33 +165,33 @@ const updateRootItems = (newItems: typeof store.rootItems) => {
   align-items: center;
   padding: 10px 16px;
   font-size: 13px;
-  color: #969696;
+  color: var(--adb-text-secondary);
 }
 
 .adb-filter-result-item {
-  color: #cccccc !important;
+  color: var(--adb-text-primary) !important;
 
   &:hover {
-    background-color: #2a2d2e !important;
+    background-color: var(--adb-bg-hover) !important;
   }
 
   &.v-list-item--active {
-    background-color: #37373d !important;
+    background-color: var(--adb-bg-active) !important;
   }
 }
 
 .adb-filter-result-item :deep(.v-list-item-title) {
-  color: #cccccc !important;
+  color: var(--adb-text-primary) !important;
   font-size: 13px;
 }
 
 .adb-filter-result-item :deep(.v-list-item-subtitle) {
-  color: #8a8a8a !important;
+  color: var(--adb-text-tertiary) !important;
   font-size: 11px;
   opacity: 1;
 }
 
 .adb-filter-result-item :deep(.v-icon) {
-  color: #b0b0b0 !important;
+  color: var(--adb-text-tertiary) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/structure/components/AdbTagFilter.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/AdbTagFilter.vue
@@ -114,21 +114,21 @@ function confirmDelete() {
 <style scoped>
 .tag-filter-field {
   margin-top: 8px;
-  border: 1px solid #555;
+  border: 1px solid var(--adb-border-light);
   border-radius: 4px;
   padding: 4px 8px 5px;
-  background-color: #3c3c3c;
+  background-color: var(--adb-bg-field);
   cursor: pointer;
 
   &:hover {
-    border-color: #777;
+    border-color: var(--adb-text-tertiary);
   }
 }
 
 .tag-filter-caption {
   display: block;
   font-size: 10px;
-  color: #969696;
+  color: var(--adb-text-secondary);
   line-height: 12px;
 }
 
@@ -141,31 +141,31 @@ function confirmDelete() {
 .tag-filter-value {
   flex: 1;
   font-size: 13px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
   &.placeholder {
-    color: #888;
+    color: var(--adb-text-tertiary);
   }
 }
 
 .tag-filter-clear {
-  color: #888;
+  color: var(--adb-text-tertiary);
 
   &:hover {
-    color: #ccc;
+    color: var(--adb-text-primary);
   }
 }
 
 .tag-filter-arrow {
-  color: #969696;
+  color: var(--adb-text-secondary);
 }
 
 .tag-filter-menu {
-  background-color: #252526;
-  border: 1px solid #454545;
+  background-color: var(--adb-bg-secondary);
+  border: 1px solid var(--adb-border-light);
   border-radius: 4px;
   padding: 4px 0;
   min-width: 220px;
@@ -176,29 +176,29 @@ function confirmDelete() {
 .tag-menu-all {
   padding: 4px 12px;
   font-size: 13px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   cursor: pointer;
 
   &:hover {
-    background-color: #2a2d2e;
+    background-color: var(--adb-bg-hover);
   }
 
   &.active {
-    color: #007fd4;
+    color: var(--adb-accent);
     font-weight: 600;
   }
 }
 
 .tag-menu-divider {
   height: 1px;
-  background-color: #3a3a3a;
+  background-color: var(--adb-border);
   margin: 4px 0;
 }
 
 .tag-menu-empty {
   padding: 6px 12px;
   font-size: 12px;
-  color: #6a6a6a;
+  color: var(--adb-text-tertiary);
   font-style: italic;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/structure/components/AdbTagFilterNode.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/AdbTagFilterNode.vue
@@ -65,22 +65,22 @@ const expanded = ref(false)
   display: flex;
   align-items: center;
   min-height: 28px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 13px;
 
   &:hover {
-    background-color: #2a2d2e;
+    background-color: var(--adb-bg-hover);
   }
 }
 
 .chevron {
-  color: #888;
+  color: var(--adb-text-tertiary);
   cursor: pointer;
   width: 18px;
   min-width: 18px;
 
   &:hover {
-    color: #ccc;
+    color: var(--adb-text-primary);
   }
 }
 
@@ -98,24 +98,24 @@ const expanded = ref(false)
   user-select: none;
 
   &:hover {
-    color: #ffffff;
+    color: var(--adb-text-inverse);
   }
 
   &.active {
-    color: #007fd4;
+    color: var(--adb-accent);
     font-weight: 600;
   }
 }
 
 .tag-delete {
-  color: #7a5a5a;
+  color: var(--adb-text-tertiary);
   opacity: 0;
   cursor: pointer;
   margin-right: 6px;
   transition: opacity 0.1s;
 
   &:hover {
-    color: #e06060;
+    color: var(--adb-danger-hover);
   }
 }
 

--- a/frontend/src/feature/aufgabendatenbank/structure/components/AdbTreeItem.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/AdbTreeItem.vue
@@ -113,7 +113,7 @@ const updateCollectionChildren = (element: Collection, newItems: TreeItem[]) => 
 <style scoped>
 .ghost {
   opacity: 0.5;
-  background: #2a2d2e;
+  background: var(--adb-bg-hover);
 }
 
 .tree-draggable {

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbConfirmDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbConfirmDialog.vue
@@ -70,21 +70,21 @@ function onCancel() {
 
 <style scoped lang="scss">
 .confirm-dialog-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
-  border: 1px solid #333;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
+  border: 1px solid var(--adb-border);
 }
 
 .confirm-dialog-title {
   font-size: 16px;
   font-weight: 600;
-  color: #e0e0e0;
+  color: var(--adb-text-primary);
   padding: 20px 24px 8px;
 }
 
 .confirm-dialog-text {
   font-size: 13px;
-  color: #999;
+  color: var(--adb-text-tertiary);
   padding: 8px 24px 16px;
   line-height: 1.5;
   white-space: pre-line;
@@ -95,23 +95,23 @@ function onCancel() {
 }
 
 .cancel-btn {
-  color: #999 !important;
+  color: var(--adb-text-tertiary) !important;
   text-transform: none;
   font-weight: 500;
 
   &:hover {
-    color: #ccc !important;
+    color: var(--adb-text-primary) !important;
   }
 }
 
 .confirm-btn {
-  background-color: #007fd4 !important;
-  color: #fff !important;
+  background-color: var(--adb-accent) !important;
+  color: var(--adb-text-inverse) !important;
   text-transform: none;
   font-weight: 600;
 
   &:hover {
-    background-color: #1a9aff !important;
+    background-color: var(--adb-accent-hover) !important;
   }
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFile.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFile.vue
@@ -171,12 +171,12 @@ const onDeleteConfirmed = () => {
   margin-bottom: 0 !important;
   border-radius: 0 !important;
   transition: none !important;
-  color: #cccccc !important;
+  color: var(--adb-text-primary) !important;
   position: relative;
   z-index: 5;
 
   &:hover {
-    background-color: #2a2d2e !important;
+    background-color: var(--adb-bg-hover) !important;
 
     .action-btn {
       opacity: 1;
@@ -184,8 +184,8 @@ const onDeleteConfirmed = () => {
   }
 
   &.v-list-item--active {
-    background-color: #37373d !important;
-    color: #ffffff !important;
+    background-color: var(--adb-bg-active) !important;
+    color: var(--adb-text-inverse) !important;
 
     &::before {
       opacity: 0 !important;
@@ -203,7 +203,7 @@ const onDeleteConfirmed = () => {
   width: 16px;
   height: 16px;
   margin-right: 4px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 
 .bullet-icon {
@@ -211,7 +211,7 @@ const onDeleteConfirmed = () => {
   width: 8px;
   min-width: 8px;
   margin-right: 10px;
-  color: #888888;
+  color: var(--adb-text-tertiary);
 }
 
 .position-number {
@@ -224,12 +224,12 @@ const onDeleteConfirmed = () => {
   margin-right: 4px;
   font-size: 11px;
   font-weight: 600;
-  color: #007fd4;
+  color: var(--adb-accent);
   line-height: 1;
 }
 
 .type-icon {
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 
 .tree-node-title {
@@ -238,7 +238,7 @@ const onDeleteConfirmed = () => {
 }
 
 .position-label {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-weight: 600;
   margin-right: 4px;
 }
@@ -250,6 +250,6 @@ const onDeleteConfirmed = () => {
 
 .drop-target {
   background-color: rgba(0, 127, 212, 0.1);
-  box-shadow: inset 0 0 0 1px #007fd4;
+  box-shadow: inset 0 0 0 1px var(--adb-accent);
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFolder.vue
+++ b/frontend/src/feature/aufgabendatenbank/structure/components/tree/AdbTreeFolder.vue
@@ -187,12 +187,12 @@ const onSelect = () => {
   border-radius: 0 !important;
   transition: none !important;
   cursor: pointer;
-  color: #cccccc !important;
+  color: var(--adb-text-primary) !important;
   position: relative;
   z-index: 5;
 
   &:hover {
-    background-color: #2a2d2e !important;
+    background-color: var(--adb-bg-hover) !important;
 
     .action-btn {
       opacity: 1;
@@ -200,8 +200,8 @@ const onSelect = () => {
   }
 
   &.v-list-item--active {
-    background-color: #37373d !important;
-    color: #ffffff !important;
+    background-color: var(--adb-bg-active) !important;
+    color: var(--adb-text-inverse) !important;
 
     &::before {
       opacity: 0 !important;
@@ -220,7 +220,7 @@ const onSelect = () => {
   height: 16px;
   margin-left: -2px;
   margin-right: 6px;
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 
 .position-number {
@@ -233,12 +233,12 @@ const onSelect = () => {
   margin-right: 4px;
   font-size: 11px;
   font-weight: 600;
-  color: #007fd4;
+  color: var(--adb-accent);
   line-height: 1;
 }
 
 .type-icon {
-  color: #cccccc;
+  color: var(--adb-text-primary);
 }
 
 .tree-node-title {
@@ -247,7 +247,7 @@ const onSelect = () => {
 }
 
 .position-label {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-weight: 600;
   margin-right: 4px;
 }
@@ -267,7 +267,7 @@ const onSelect = () => {
     top: 0;
     bottom: 0;
     width: 1px;
-    background-color: #5a5a5a;
+    background-color: var(--adb-tree-connector);
     pointer-events: none;
     z-index: 10;
   }
@@ -280,7 +280,7 @@ const onSelect = () => {
 
 .drop-target {
   background-color: rgba(0, 127, 212, 0.1);
-  box-shadow: inset 0 0 0 1px #007fd4;
+  box-shadow: inset 0 0 0 1px var(--adb-accent);
 }
 
 .loading-spinner {
@@ -288,7 +288,7 @@ const onSelect = () => {
   align-items: center;
   gap: 8px;
   padding: 8px 16px 8px 48px;
-  color: #888;
+  color: var(--adb-text-tertiary);
   font-size: 12px;
 }
 

--- a/frontend/src/feature/aufgabendatenbank/toolbar/AdbCreateDialog.vue
+++ b/frontend/src/feature/aufgabendatenbank/toolbar/AdbCreateDialog.vue
@@ -105,21 +105,21 @@ function confirm() {
 
 <style scoped>
 .create-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
 }
 
 .create-title {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 16px;
   font-weight: 600;
 }
 
 .cancel-btn {
-  color: #969696 !important;
+  color: var(--adb-text-secondary) !important;
 }
 
 .confirm-btn {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/toolbar/AdbFilters.vue
+++ b/frontend/src/feature/aufgabendatenbank/toolbar/AdbFilters.vue
@@ -108,8 +108,8 @@ function clearAll() {
   align-items: center;
   gap: 8px;
   padding: 6px 16px;
-  background-color: #1e1e1e;
-  border-bottom: 1px solid #333333;
+  background-color: var(--adb-bg-primary);
+  border-bottom: 1px solid var(--adb-border);
   flex-wrap: wrap;
 }
 
@@ -137,8 +137,8 @@ function clearAll() {
 }
 
 :deep(.v-field) {
-  background-color: #2d2d2d !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-surface) !important;
+  color: var(--adb-text-primary) !important;
   border-radius: 4px;
 }
 
@@ -149,16 +149,16 @@ function clearAll() {
 }
 
 :deep(.v-field__input) {
-  color: #cccccc !important;
+  color: var(--adb-text-primary) !important;
   font-size: 0.8125rem;
 }
 
 :deep(.v-field__input::placeholder) {
-  color: #9a9a9a !important;
+  color: var(--adb-text-tertiary) !important;
   opacity: 1 !important;
 }
 
 :deep(.v-field--variant-outlined .v-field__outline) {
-  color: #555555 !important;
+  color: var(--adb-border-light) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/toolbar/AdbRefSelect.vue
+++ b/frontend/src/feature/aufgabendatenbank/toolbar/AdbRefSelect.vue
@@ -149,21 +149,21 @@ async function confirm() {
 }
 
 .ref-card {
-  background-color: #1e1e1e !important;
-  color: #cccccc !important;
+  background-color: var(--adb-bg-primary) !important;
+  color: var(--adb-text-primary) !important;
 }
 
 .ref-title {
-  color: #cccccc;
+  color: var(--adb-text-primary);
   font-size: 15px;
   font-weight: 600;
 }
 
 .cancel-btn {
-  color: #969696 !important;
+  color: var(--adb-text-secondary) !important;
 }
 
 .confirm-btn {
-  color: #007fd4 !important;
+  color: var(--adb-accent) !important;
 }
 </style>

--- a/frontend/src/feature/aufgabendatenbank/validation.ts
+++ b/frontend/src/feature/aufgabendatenbank/validation.ts
@@ -5,58 +5,51 @@ export interface ValidationIssue {
   message: string
 }
 
-// ── Tree flattening ──────────────────────────────────────────────────────────
 
-/** Recursively flatten a collection's items[] into a single-level array. */
+
+
 function flattenCollectionItems(items: CollectionItem[] | undefined): Item[] {
   return (items ?? []).flatMap(ci =>
-    // Drill into nested collections to collect their items too
     checkIsCollection(ci.item)
       ? [ci.item, ...flattenCollectionItems(ci.item.items)]
       : [ci.item]
   )
 }
 
-/** Flatten rootItems + all nested collection items into one flat array. */
 function flattenAllItems(rootItems: Item[]): Item[] {
   return rootItems.flatMap(item =>
-    // Unpack collection contents alongside the collection node itself
     checkIsCollection(item)
       ? [item, ...flattenCollectionItems(item.items)]
       : [item]
   )
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Best-effort human-readable label: first content text, falling back to ID. */
+
+
 function getItemTitle(item: Item): string {
   return item.contents?.[0]?.jsonContent?.text ?? item.id
 }
 
-/** Wrap a message string into a ValidationIssue. */
+
 function toIssue(message: string): ValidationIssue {
   return { message }
 }
 
-// ── Rule 1: Only collections may have children ───────────────────────────────
+// Regel 1: Nur Kollektionen dürfen Kinder haben
 
 export function checkOnlyCollectionsHaveChildren(items: Item[]): ValidationIssue[] {
   return items
-    // Keep only non-collection items (exercises etc.)
     .filter(item => !checkIsCollection(item))
-    // Of those, keep only the ones that unexpectedly have children
     .filter(item => item.items !== undefined && item.items.length > 0)
-    // Convert each violation into a human-readable issue
     .map(item => toIssue(
       `"${getItemTitle(item)}" ist kein Collection-Item, hat aber ${item.items!.length} Kind-Elemente.`
     ))
 }
 
-// ── Rule 2: No item may appear both in rootItems and inside a collection ─────
+// Regel 2: Kein Item darf sowohl in rootItems als auch in einer Kollektion sein
 
 export function checkNoDuplicateItems(rootItems: Item[]): ValidationIssue[] {
-  // Build a set of every item ID that lives nested inside any collection
   const idsInsideCollections = new Set(
     rootItems
       .filter(checkIsCollection)
@@ -65,33 +58,30 @@ export function checkNoDuplicateItems(rootItems: Item[]): ValidationIssue[] {
   )
 
   return rootItems
-    // Keep only root-level items whose ID also appears inside a collection
+    // Nur Root-Items, deren ID auch in einer Kollektion vorkommt
     .filter(item => idsInsideCollections.has(item.id))
     .map(item => toIssue(
       `"${getItemTitle(item)}" (${item.id}) ist sowohl in rootItems als auch in einer Kollektion enthalten.`
     ))
 }
 
-// ── Rule 3: Every rootItemId reference must resolve ─────────────────────────
+// Regel 3: Jede rootItemId-Referenz muss auflösbar sein
 
 export function checkNoDanglingRootItemId(items: Item[]): ValidationIssue[] {
-  // Index all known item IDs for O(1) lookup
   const allIds = new Set(items.map(i => i.id))
 
   return items
-    // Narrow type: keep only items that actually have a rootItemId set
+    // Nur Items mit rootItemId, deren Referenz im Baum nicht existiert
     .filter((item): item is Item & { rootItemId: string } => !!item.rootItemId)
-    // Of those, keep only items whose rootItemId points to nothing in the tree
     .filter(item => !allIds.has(item.rootItemId))
     .map(item => toIssue(
       `"${getItemTitle(item)}" verweist auf rootItemId "${item.rootItemId}", das nicht existiert.`
     ))
 }
 
-// ── Composed validator ───────────────────────────────────────────────────────
+// Zusammengesetzter Validator
 
 export function validateTreeData(rootItems: Item[]): ValidationIssue[] {
-  // Pre-compute a flat view so each check doesn't have to re-traverse
   const allItems = flattenAllItems(rootItems)
 
   return [

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -13,8 +13,6 @@ export interface Content {
   jsonContent: Record<string, any>
   blobContent: string
 
-  // Backend-IDs (für Dropdown-Auswahl). Optional, da viele Stellen
-  // Content-Objekte als Literal bauen.
   authorId?: string | null
   licenseId?: string | null
   contentTypeId?: string | null
@@ -34,11 +32,7 @@ export interface Item {
   contents: Content[]
   items?: CollectionItem[]
   order?: boolean
-  // Backend item_collection_id (nur bei Kollektionen gesetzt). Wird für
-  // alle /api/collections/{id}/... Aufrufe verwendet — NICHT die item_id (id).
   collectionId?: string | null
-  // Backend-IDs für Dropdown-Auswahl (Autor/Lizenz/Typ). Optional, da
-  // viele Stellen Item-Objekte als Literal bauen.
   authorId?: string | null
   licenseId?: string | null
   itemTypeId?: string | null

--- a/frontend/src/plugins/vuetify.ts
+++ b/frontend/src/plugins/vuetify.ts
@@ -1,25 +1,36 @@
-/**
- * plugins/vuetify.js
- *
- * Framework documentation: https://vuetifyjs.com`
- */
-
-// Styles
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
-
-// Composables
 import { createVuetify } from "vuetify";
 
-// https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
   components: {},
   theme: {
+    defaultTheme: "light",
     themes: {
       light: {
+        dark: false,
         colors: {
-          background: "#FFFFFF",
+          background: "#FAFAFA",
           surface: "#FFFFFF",
+          primary: "#81BA24",
+          "primary-dark": "#4F8A00",
+          "primary-light": "#B4ED59",
+          secondary: "#03DAC6",
+          "secondary-darken-1": "#018786",
+          "dark-gray": "#414958",
+          black: "#1F242E",
+          white: "#FFFFFF",
+          error: "#e60000",
+          info: "#2196F3",
+          success: "#4CAF50",
+          warning: "#FB8C00",
+        },
+      },
+      dark: {
+        dark: true,
+        colors: {
+          background: "#1e1e1e",
+          surface: "#252526",
           primary: "#81BA24",
           "primary-dark": "#4F8A00",
           "primary-light": "#B4ED59",

--- a/frontend/src/stores/exerciseStore.ts
+++ b/frontend/src/stores/exerciseStore.ts
@@ -28,34 +28,25 @@ import type {
   SearchParams
 } from '@/feature/aufgabendatenbank/api-adapter.types'
 
-/** Ein Knoten im hierarchischen Tag-Baum (für die Filter-Auswahl). */
 export interface TagNode {
   id: string
   tag: string
   children: TagNode[]
 }
 
-// ── Default-UUIDs (identisch mit database/init/init.sql) ───────────────────────
-// Werden genutzt, solange der Benutzer im UI keine eigene Auswahl trifft.
-
+// Default-UUIDs identisch mit database/init/init.sql
 const DEFAULT_AUTHOR_ID = 'd0000000-0000-0000-0000-000000000001'
 const DEFAULT_LICENSE_ID = 'b0000000-0000-0000-0000-000000000001'
 const DEFAULT_ITEM_TYPE_ID = 'e0000000-0000-0000-0000-000000000001'
 const DEFAULT_CONTENT_TYPE_ID = 'a0000000-0000-0000-0000-000000000003'
 
-// ── Adapter injection ─────────────────────────────────────────────────────────
-
 let _adapter: ApiAdapter | null = null
 
-/**
- * Inject the API adapter into the exercise store.
- * Must be called before `useExerciseStore()` is invoked.
- */
 export function setApiAdapter(adapter: ApiAdapter): void {
   _adapter = adapter
 }
 
-// ── DTO → Store type mappers ──────────────────────────────────────────────────
+
 
 function toContent(dto: ContentSummaryDTO): Content {
   return {
@@ -108,9 +99,6 @@ function toItem(dto: ItemDTO): Item {
     modifiers: dto.modifierIds ?? [],
     rootItemId: dto.rootItemId ?? null,
     contents: (dto.contents ?? []).map(toContent),
-    // Eine Kollektion hat IMMER ein items-Array (zunächst leer, bis die
-    // Kinder via _loadChildrenRecursively nachgeladen werden). Sonst
-    // crasht z. B. die Validierung mit undefined.flatMap(...).
     items: dto.items?.map(toCollectionItem) ?? (dto.isCollection ? [] : undefined),
     order: dto.order,
     collectionId: dto.collectionId ?? null,
@@ -130,7 +118,7 @@ function toCollectionItem(dto: CollectionItemDTO): CollectionItem {
   }
 }
 
-// ── State ─────────────────────────────────────────────────────────────────────
+
 
 interface ExerciseState {
   rootItems: Item[]
@@ -140,17 +128,13 @@ interface ExerciseState {
   loadingContent: boolean
   error: string | null
   loadingChildrenIds: string[]
-  // Referenzdaten für Dropdowns (Autor/Lizenz/Typ/Content-Typ)
   authors: AuthorDTO[]
   licenses: LicenseDTO[]
   itemTypes: ItemTypeDTO[]
   contentTypes: ContentTypeDTO[]
-  // Hierarchische Tags + aktiver Tag-Filter (null = kein Filter)
   tags: TagDTO[]
   tagFilter: string | null
-  // Templates für die Darstellung der Contents
   templates: ReprTemplateDTO[]
-  // Erstellungs-Dialog (von Toolbar und Collection-Kontextmenü geteilt)
   createDialogOpen: boolean
   createDialogTarget: Collection | null
   allValidators: ValidatorDTO[]
@@ -158,10 +142,7 @@ interface ExerciseState {
   selectedLicenseId: string | null
   selectedItemTypeId: string | null
   selectedContentTypeId: string | null
-  // Aktuelle Live-XML aus dem Editor, damit _getTemplateXml / _ensurePurpose / _removePurpose
-  // gegen die aktuellste Version mergen und nicht gegen eine veraltete persisted template.
   liveTemplateXml: string | null
-  // Such-/Filterzustand
   searchQuery: string
   filterAuthorId: string | null
   filterItemTypeId: string | null
@@ -170,11 +151,11 @@ interface ExerciseState {
   filtering: boolean
 }
 
-// ── Debounce timer (module-level, nicht im Store-State) ──────────────────────
+
 
 let _filterTimer: ReturnType<typeof setTimeout> | null = null
 
-// ── Store ─────────────────────────────────────────────────────────────────────
+
 
 export const useExerciseStore = defineStore('exercise', {
   state: (): ExerciseState => ({
@@ -219,8 +200,6 @@ export const useExerciseStore = defineStore('exercise', {
       return getInnerItem(state.selectedItem)
     },
 
-    // Default-IDs für die Erstellung: erster Eintrag der jeweiligen
-    // Referenzliste, Fallback auf die festen Seed-UUIDs (falls Liste leer).
     defaultAuthorId: (state): string => state.authors[0]?.id ?? DEFAULT_AUTHOR_ID,
     defaultLicenseId: (state): string => state.licenses[0]?.id ?? DEFAULT_LICENSE_ID,
     defaultItemTypeId: (state): string => state.itemTypes[0]?.id ?? DEFAULT_ITEM_TYPE_ID,
@@ -241,9 +220,6 @@ export const useExerciseStore = defineStore('exercise', {
       return coll ? coll.order === true : false
     },
 
-    // ── Tags ──────────────────────────────────────────────────────────────────
-
-    /** Lesbarer Pfad eines Tags, z. B. "Mathematik / Analysis / Ableitungen". */
     tagPath() {
       return (id: string): string => {
         const parts: string[] = []
@@ -258,14 +234,12 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /** Alle Tags als { id, path } für Dropdowns, nach Pfad sortiert. */
     tagOptions(): { id: string; path: string }[] {
       return this.tags
         .map((t) => ({ id: t.id, path: this.tagPath(t.id) }))
         .sort((a, b) => a.path.localeCompare(b.path))
     },
 
-    /** Hierarchischer Tag-Baum (nur Wurzeln, mit verschachtelten Kindern). */
     tagTree(): TagNode[] {
       const byId = new Map<string, TagNode>()
       for (const t of this.tags) byId.set(t.id, { id: t.id, tag: t.tag, children: [] })
@@ -284,7 +258,6 @@ export const useExerciseStore = defineStore('exercise', {
       return roots
     },
 
-    /** Ein Tag plus alle seine Nachfahren (für den vererbenden Filter). */
     descendantTagIds() {
       return (id: string): Set<string> => {
         const ids = new Set<string>([id])
@@ -302,11 +275,6 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /**
-     * Root-Items unter Berücksichtigung des Tag-Filters. Ohne Filter alle;
-     * mit Filter nur Items, deren Tags den gewählten Tag oder einen seiner
-     * Nachfahren enthalten (Vererbung).
-     */
     visibleRootItems(): Item[] {
       if (!this.tagFilter) return this.rootItems
       const wanted = this.descendantTagIds(this.tagFilter)
@@ -330,9 +298,6 @@ export const useExerciseStore = defineStore('exercise', {
   },
 
   actions: {
-    // ── Notifications ─────────────────────────────────────────────────────────
-
-    /** Push an API error string to the global notification store. */
     _notifyError(e: unknown) {
       const notifStore = useNotificationStore()
       const msg = (e as any)?.response?.data?.message || (e as any)?.response?.data || String(e)
@@ -340,12 +305,8 @@ export const useExerciseStore = defineStore('exercise', {
       notifStore.push(status + JSON.stringify(msg), 'error', 12000)
     },
 
-    // ── Referenzdaten ─────────────────────────────────────────────────────────
 
-    /**
-     * Load reference lists (authors, licenses, item types, content types)
-     * used to populate the editor dropdowns. Called once on mount.
-     */
+
     async loadReferenceData() {
       if (!_adapter) return
       try {
@@ -375,12 +336,7 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /**
-     * Neue Referenzdaten anlegen (Autor/Lizenz/Typ/Inhaltstyp). Legt sie per
-     * POST an, hängt sie an die passende Liste und gibt den neuen Datensatz
-     * zurück, damit die UI ihn direkt auswählen kann.
-     * `primary` = Name/Descriptor, `secondary` = Mail (Autor) bzw. Beschreibung.
-     */
+    /** Neue Referenzdaten anlegen, an die Liste anhängen und zurückgeben. */
     async createReference(
       type: 'author' | 'license' | 'itemType' | 'contentType',
       primary: string,
@@ -430,9 +386,6 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    // ── Tags ────────────────────────────────────────────────────────────────
-
-    /** Neues Tag anlegen (optional mit Eltern-Tag) und in die Liste aufnehmen. */
     async createTag(
       name: string,
       parentTagId: string | null = null,
@@ -453,11 +406,7 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /**
-     * Erstellt einen Tag aus einem Pfad "A/B/C": bestehende Segmente werden
-     * per Name wiederverwendet, fehlende neu angelegt. Leerzeichen sind
-     * verboten (auch zwischen Wörtern). Gibt den Blatt-Tag zurück.
-     */
+    /** Erstellt Tag aus Pfad "A/B/C": bestehende Segmente werden wiederverwendet, fehlende neu angelegt. */
     async createTagPath(
       rawName: string,
       parentId: string | null = null,
@@ -476,8 +425,7 @@ export const useExerciseStore = defineStore('exercise', {
         const isLeaf = i === segments.length - 1
         const existing = this.tags.find((t) => t.tag.toLowerCase() === seg.toLowerCase())
         if (existing) {
-          // Ein bereits existierender Blatt-Tag ist ein Duplikat -> Fehler.
-          // Nur Zwischenebenen (Vorfahren) werden wiederverwendet.
+          // Nur Zwischenebenen werden wiederverwendet, doppelte Blätter sind ein Fehler.
           if (isLeaf) {
             useNotificationStore().push(`Tag „${seg}" existiert bereits.`, 'error', 6000)
             return null
@@ -494,11 +442,7 @@ export const useExerciseStore = defineStore('exercise', {
       return leaf
     },
 
-    /**
-     * Tag einem Item zuordnen (optimistisch). Exklusivität: bereits
-     * zugewiesene Vorfahren oder Nachfahren desselben Astes werden entfernt,
-     * da der spezifischste Tag die übrigen Ebenen bereits impliziert.
-     */
+    /** Tag optimistisch zuordnen. Entfernt Vorfahren/Nachfahren desselben Astes. */
     assignTagToItem(item: Item, tagId: string) {
       if (!tagId || item.tags.includes(tagId)) return
       const related = this._relatedTagIds(tagId)
@@ -543,11 +487,7 @@ export const useExerciseStore = defineStore('exercise', {
       this.tagFilter = tagId
     },
 
-    /**
-     * Einen Tag vollständig löschen. Backend + Datenbank räumen die Folgen auf
-     * (Unter-Tags werden zu Wurzel-Tags, Zuordnungen verschwinden). Der lokale
-     * Zustand wird passend nachgezogen.
-     */
+    /** Tag vollständig löschen. Unter-Tags werden zu Wurzel-Tags. */
     async deleteTag(tagId: string) {
       if (!_adapter) return
       try {
@@ -575,15 +515,6 @@ export const useExerciseStore = defineStore('exercise', {
       walk(this.rootItems)
     },
 
-    // ── Initialisation (progressive loading) ──────────────────────────────────
-
-    /**
-     * Load the exercise tree progressively.
-     *
-     * Phase 1: `getRootItems()` — roots appear in the UI immediately.
-     * Phase 2: `_loadChildrenRecursively()` — each collection's children
-     * load in the background with a per-node spinner in the tree view.
-     */
     async loadTree() {
       this.loading = true
       this.error = null
@@ -593,7 +524,7 @@ export const useExerciseStore = defineStore('exercise', {
           this.loadValidators()
         ])
         this.rootItems = dtos.map(toItem)
-        // Fire background recursive loading — no await so UI shows roots now
+        // No await — UI shows roots immediately, children load in background
         this._loadChildrenRecursively(this.rootItems)
       } catch (e) {
         this.error = String(e)
@@ -603,22 +534,12 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /**
-     * Recursively load children for every collection in `items`.
-     *
-     * Each collection is flagged in `loadingChildrenIds` while its
-     * children are being fetched. Sub-collections inside the loaded
-     * children trigger their own fetch. All siblings at the same depth
-     * load in parallel.
-     */
     async _loadChildrenRecursively(items: Item[]) {
       const promises = items
         .filter((item) => item.item_type === 'collection' || checkIsCollection(item))
         .map(async (item) => {
           const collection = item as Collection
-          // Kollektion-Endpunkte brauchen die item_collection_id, nicht die item_id.
-          // Fehlt sie (z. B. optimistisch angelegt, Backend-Antwort noch unterwegs),
-          // überspringen — der Reload liefert sie später.
+          // Collection endpoints need item_collection_id, not item_id.
           if (!collection.collectionId) return
           this.loadingChildrenIds = [...this.loadingChildrenIds, collection.id]
           try {
@@ -635,7 +556,7 @@ export const useExerciseStore = defineStore('exercise', {
       await Promise.all(promises)
     },
 
-    // ── Search / Filters ──────────────────────────────────────────────────────
+
 
     setSearchQuery(query: string) {
       this.searchQuery = query
@@ -697,7 +618,7 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    // ── Selection ─────────────────────────────────────────────────────────────
+
 
     selectItem(item: TreeItem) {
       this.liveTemplateXml = null
@@ -773,7 +694,7 @@ export const useExerciseStore = defineStore('exercise', {
       this._syncOrderedCollectionItems(collection)
     },
 
-    // ── Validator Actions ────────────────────────────────────────────────────
+
 
     async loadValidators() {
       try {
@@ -821,7 +742,7 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    // ── Content Actions ───────────────────────────────────────────────────────
+
 
     addContentToSelectedItem() {
       const inner = this.selectedInnerItem
@@ -950,7 +871,7 @@ export const useExerciseStore = defineStore('exercise', {
       return _adapter.getBlobUrl(contentId)
     },
 
-    // ── Template XML Actions ─────────────────────────────────────────────────
+
 
     _getTemplateXml(): string | null {
       if (this.liveTemplateXml) return this.liveTemplateXml
@@ -1028,7 +949,7 @@ export const useExerciseStore = defineStore('exercise', {
       this._saveTemplateXml(xml)
     },
 
-    // ── Variants ────────────────────────────────────────────────────────────────
+
 
     /**
      * Zählt die Varianten eines Items (Items mit root_item_id === itemId),
@@ -1168,12 +1089,8 @@ export const useExerciseStore = defineStore('exercise', {
         this._notifyError(e)
       }
     },
-    // ── Tree helpers ──
 
-    /**
-     * Remove an item from all collections and from rootItems.
-     * @returns The ID of the parent collection the item was removed from, or null.
-     */
+
     _detachItem(itemId: string, excludeId?: string): string | null {
       let parentId: string | null = null
       const removeFromCollections = (collections: Collection[]) => {
@@ -1190,9 +1107,6 @@ export const useExerciseStore = defineStore('exercise', {
       return parentId
     },
 
-    /**
-     * Walk the tree to find a collection by ID.
-     */
     _findCollectionById(id: string, items?: Item[]): Collection | null {
       const searchItems = items ?? this.rootItems
       for (const item of searchItems) {
@@ -1206,7 +1120,7 @@ export const useExerciseStore = defineStore('exercise', {
       return null
     },
 
-    /** Build a minimal Item object with a unique ID and single Content block. */
+
     _createItemData(rootItemId: string | null = null): Item {
       const now = Date.now().toString()
       const authorId = this.defaultAuthorId
@@ -1249,21 +1163,6 @@ export const useExerciseStore = defineStore('exercise', {
       }
     },
 
-    /**
-     * After a mutation to an ordered collection, diff the current
-     * positions against their expected sequential order and push
-     * any changes to the API.
-     *
-     * Only fires when `collection.order === true`.
-     */
-    /**
-     * Persist positions for an ordered collection.
-     *
-     * @param collection - The collection to sync.
-     * @param force - When `true`, call the API for every item regardless
-     * of whether its local position already matches. Used after DnD reorder
-     * where positions are pre-set in `.map()` but still need to be persisted.
-     */
     _syncOrderedCollectionItems(collection: Collection, force = false) {
       if (!collection.order || !_adapter || !collection.collectionId) return
       const collectionId = collection.collectionId
@@ -1277,13 +1176,8 @@ export const useExerciseStore = defineStore('exercise', {
       })
     },
 
-    // ── CRUD Actions ──
 
-    /**
-     * Update an item's metadata (author / license / item-type) from the
-     * editor dropdowns. Updates the local item (incl. display labels) and
-     * persists via PUT /items/{id}.
-     */
+
     updateItemMeta(item: Item, meta: { authorId?: string; licenseId?: string; itemTypeId?: string; itemTemplateId?: string }) {
       if (meta.authorId !== undefined) item.authorId = meta.authorId
       if (meta.licenseId !== undefined) item.licenseId = meta.licenseId
@@ -1338,11 +1232,6 @@ export const useExerciseStore = defineStore('exercise', {
       return item
     },
 
-    /**
-     * Create an item from the creation form. Uses the chosen Typ/Autor/Lizenz
-     * (or defaults when left empty — the form is not strict) and the entered
-     * task text as the first content. Selects the new item afterwards.
-     */
     createItemFromForm(
       form: { itemTypeId?: string; authorId?: string; licenseId?: string; text?: string },
       target: Collection | null = null
@@ -1405,7 +1294,7 @@ export const useExerciseStore = defineStore('exercise', {
       return item
     },
 
-    // ── Erstellungs-Dialog (geteilter Zustand) ──
+    // Create dialog (shared state)
     openCreateDialog(target: Collection | null = null) {
       this.createDialogTarget = target
       this.createDialogOpen = true
@@ -1517,7 +1406,7 @@ export const useExerciseStore = defineStore('exercise', {
       itemsToDelete.forEach((ci) => this.deleteItem(ci.item))
     },
 
-    // ── DnD / Reorder Actions ──
+
 
     updateCollectionItems(collection: Collection, newItems: TreeItem[]) {
       collection.items = newItems.map((item, index) => {
@@ -1582,7 +1471,7 @@ export const useExerciseStore = defineStore('exercise', {
       this.validate()
     },
 
-    // ── Validation ──
+
 
     validate() {
       const issues = validateTreeData(this.rootItems)

--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import { useTheme } from 'vuetify'
+import { watch } from 'vue'
+
+const STORAGE_KEY = 'adb-theme'
+
+function getInitialTheme(): string {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'dark' || stored === 'light') return stored
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark'
+  return 'light'
+}
+
+export const useThemeStore = defineStore('theme', () => {
+  const theme = useTheme()
+  const current = theme.global.name
+
+  function init() {
+    const saved = getInitialTheme()
+    theme.global.name.value = saved
+  }
+
+  function toggle() {
+    const next = theme.global.name.value === 'dark' ? 'light' : 'dark'
+    theme.global.name.value = next
+    localStorage.setItem(STORAGE_KEY, next)
+  }
+
+  const isDark = () => theme.global.name.value === 'dark'
+
+  watch(() => theme.global.name.value, (val) => {
+    document.documentElement.setAttribute('data-theme', val as string)
+  }, { immediate: true })
+
+  return { init, toggle, isDark, current }
+})

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   ADB Theme Variables – Dark Mode (current look)
+   ============================================================ */
+[data-theme="dark"] {
+  --adb-bg-primary: #1e1e1e;
+  --adb-bg-secondary: #252526;
+  --adb-bg-surface: #2d2d2d;
+  --adb-bg-hover: #2a2d2e;
+  --adb-bg-active: #37373d;
+  --adb-bg-field: #3c3c3c;
+  --adb-bg-card: #1e1e1e;
+  --adb-bg-dialog: #2d2d2d;
+  --adb-bg-chip: #2a2a2a;
+
+  --adb-text-primary: #cccccc;
+  --adb-text-secondary: #969696;
+  --adb-text-tertiary: #888888;
+  --adb-text-muted: #555555;
+  --adb-text-inverse: #ffffff;
+
+  --adb-border: #3c3c3c;
+  --adb-border-light: #555555;
+
+  --adb-accent: #007fd4;
+  --adb-accent-hover: #1a9aff;
+  --adb-danger: #c04040;
+  --adb-danger-hover: #e06060;
+  --adb-success: #4caf50;
+  --adb-warning: #ffc107;
+
+  --adb-icon: #888888;
+  --adb-icon-hover: #cccccc;
+  --adb-tree-connector: #5a5a5a;
+}
+
+/* ============================================================
+   ADB Theme Variables – Light Mode
+   ============================================================ */
+[data-theme="light"] {
+  --adb-bg-primary: #fafafa;
+  --adb-bg-secondary: #ffffff;
+  --adb-bg-surface: #ffffff;
+  --adb-bg-hover: #e8e8e8;
+  --adb-bg-active: #d0d0d0;
+  --adb-bg-field: #f0f0f0;
+  --adb-bg-card: #ffffff;
+  --adb-bg-dialog: #ffffff;
+  --adb-bg-chip: #e8e8e8;
+
+  --adb-text-primary: #1e1e1e;
+  --adb-text-secondary: #555555;
+  --adb-text-tertiary: #777777;
+  --adb-text-muted: #999999;
+  --adb-text-inverse: #000000;
+
+  --adb-border: #dddddd;
+  --adb-border-light: #cccccc;
+
+  --adb-accent: #007acc;
+  --adb-accent-hover: #005999;
+  --adb-danger: #d32f2f;
+  --adb-danger-hover: #b71c1c;
+  --adb-success: #388e3c;
+  --adb-warning: #f57c00;
+
+  --adb-icon: #666666;
+  --adb-icon-hover: #333333;
+  --adb-tree-connector: #bbbbbb;
+}


### PR DESCRIPTION
- Vuetify-Konfiguration um Dark-Theme erweitert
- Theme-Store mit localStorage-Persistenz und System-Praferenz
- CSS-Variablen (--adb-bg, --adb-text, --adb-border, ...) fur Dark/Light
- Toggle-Button in beide Header-Varianten eingebaut
- ~196 hartcodierte Farben in 23 Komponenten durch CSS-Vars ersetzt
- 22 Frontend-Tests weiterhin grun